### PR TITLE
Add announcement banner and expand AI tool catalog

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,39 +3,278 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>AI Tools Mind‑map (Vanilla)</title>
+  <title>AI Compass — карта ШІ сервісів</title>
+  <link
+    rel="icon"
+    type="image/svg+xml"
+    href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Cdefs%3E%3ClinearGradient id='g' x1='0' y1='0' x2='1' y2='1'%3E%3Cstop offset='0' stop-color='%231e3a8a'/%3E%3Cstop offset='1' stop-color='%230ea5e9'/%3E%3C/linearGradient%3E%3C/defs%3E%3Ccircle cx='32' cy='32' r='30' fill='url(%23g)'/%3E%3Cpolygon points='32,14 41,32 32,50 23,32' fill='%23f8fafc'/%3E%3Ccircle cx='32' cy='32' r='6' fill='%231f2937'/%3E%3C/svg%3E"
+  />
   <style>
-    html, body { height: 100%; margin:0; background:#f9fafb; font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji"; }
-    .wrap { padding: 16px; max-width: 1200px; margin: 0 auto; }
-    .bar { display:flex; align-items:center; justify-content:space-between; margin-bottom:12px; }
-    .btn { border:0; padding:6px 10px; border-radius:8px; cursor:pointer; background:#e5e7eb; }
-    .btn.active { background:#2563eb; color:#fff; }
-    .card { background:#fff; border-radius:16px; box-shadow: 0 8px 24px rgba(0,0,0,0.06); overflow:auto; }
-    svg { display:block; width:100%; height:auto; min-height:640px; }
-    .tip { pointer-events:none; }
-    .small { font-size:10px; font-weight:600; fill:#111827; }
-    .normal { font-size:12px; font-weight:600; fill:#111827; }
-    .large { font-size:16px; font-weight:700; fill:#111827; }
-    .muted { font-size:13px; font-weight:500; fill:#e5e7eb; }
-    .link { font-size:11px; fill:#60a5fa; text-decoration:underline; }
+    html,
+    body {
+      height: 100%;
+    }
+    body {
+      margin: 0;
+      min-height: 100%;
+      display: flex;
+      flex-direction: column;
+      background: #f9fafb;
+      color: #111827;
+      font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji";
+    }
+    main {
+      flex: 1;
+    }
+    .wrap {
+      width: 100%;
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 0 16px;
+      box-sizing: border-box;
+    }
+    .top-banner {
+      background: #1f2937;
+      color: #f9fafb;
+      border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+    }
+    .banner-inner {
+      padding: 10px 16px;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 12px;
+      font-size: 13px;
+      letter-spacing: 0.01em;
+      text-align: center;
+    }
+    .banner-pill {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 4px 10px;
+      border-radius: 999px;
+      background: rgba(255, 255, 255, 0.12);
+      color: #e0f2fe;
+      font-weight: 600;
+      font-size: 12px;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+    }
+    .hero {
+      background: linear-gradient(135deg, #dbeafe 0%, #f8fafc 100%);
+      border-bottom: 1px solid #e5e7eb;
+    }
+    .hero-inner {
+      padding: 48px 16px;
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+      align-items: flex-start;
+    }
+    .hero-label {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      background: #1d4ed8;
+      color: #fff;
+      padding: 6px 14px;
+      border-radius: 999px;
+      font-size: 13px;
+      font-weight: 600;
+      letter-spacing: 0.02em;
+      text-transform: uppercase;
+    }
+    .hero-title {
+      margin: 0;
+      font-size: 32px;
+      line-height: 1.2;
+      font-weight: 700;
+      color: #0f172a;
+    }
+    .hero-subtitle {
+      margin: 0;
+      font-size: 18px;
+      font-weight: 600;
+      color: #1f2937;
+    }
+    .hero-description {
+      margin: 0;
+      max-width: 640px;
+      font-size: 15px;
+      line-height: 1.6;
+      color: #374151;
+    }
+    .main-content {
+      padding: 40px 16px 48px;
+    }
+    .bar {
+      display: flex;
+      align-items: flex-end;
+      justify-content: space-between;
+      margin-bottom: 18px;
+      flex-wrap: wrap;
+      gap: 12px;
+    }
+    .map-heading {
+      margin: 0;
+      font-size: 22px;
+      font-weight: 700;
+      color: #0f172a;
+    }
+    .language-toggle {
+      display: inline-flex;
+      gap: 8px;
+    }
+    .btn {
+      border: 0;
+      padding: 8px 14px;
+      border-radius: 10px;
+      cursor: pointer;
+      background: #e5e7eb;
+      font-size: 13px;
+      font-weight: 600;
+      color: #1f2937;
+      transition: background 0.2s ease, color 0.2s ease;
+    }
+    .btn:hover {
+      background: #d1d5db;
+    }
+    .btn.active {
+      background: #2563eb;
+      color: #fff;
+      box-shadow: 0 8px 16px rgba(37, 99, 235, 0.18);
+    }
+    .card {
+      background: #fff;
+      border-radius: 16px;
+      box-shadow: 0 12px 32px rgba(15, 23, 42, 0.12);
+      overflow: auto;
+      border: 1px solid #e5e7eb;
+    }
+    svg {
+      display: block;
+      width: 100%;
+      height: auto;
+      min-height: 640px;
+    }
+    .info-note {
+      color: #4b5563;
+      font-size: 13px;
+      margin-top: 14px;
+      line-height: 1.5;
+    }
+    .tip {
+      pointer-events: none;
+    }
+    .small {
+      font-size: 11px;
+      font-weight: 600;
+      fill: #111827;
+    }
+    .normal {
+      font-size: 12px;
+      font-weight: 600;
+      fill: #111827;
+    }
+    .large {
+      font-size: 16px;
+      font-weight: 700;
+      fill: #111827;
+    }
+    .muted {
+      font-size: 13px;
+      font-weight: 500;
+      fill: #e5e7eb;
+    }
+    .link {
+      font-size: 11px;
+      fill: #60a5fa;
+      text-decoration: underline;
+    }
+    .site-footer {
+      background: #0f172a;
+      color: #e5e7eb;
+      padding: 28px 0;
+      border-top: 1px solid rgba(255, 255, 255, 0.08);
+    }
+    .footer-inner {
+      padding: 0 16px;
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      font-size: 13px;
+      line-height: 1.6;
+    }
+    .footer-title {
+      font-weight: 600;
+      color: #f9fafb;
+      letter-spacing: 0.01em;
+    }
+    @media (max-width: 640px) {
+      .hero-inner {
+        padding: 36px 16px;
+      }
+      .hero-title {
+        font-size: 26px;
+      }
+      .hero-subtitle {
+        font-size: 16px;
+      }
+      .main-content {
+        padding: 32px 16px 40px;
+      }
+      svg {
+        min-height: 540px;
+      }
+    }
   </style>
 </head>
 <body>
-  <div class="wrap">
-    <div class="bar">
-      <h1>AI Tools Mind‑map</h1>
-      <div>
-        <button id="uaBtn" class="btn active">UA</button>
-        <button id="enBtn" class="btn">EN</button>
-      </div>
+  <div class="top-banner">
+    <div class="wrap banner-inner">
+      <span class="banner-pill">AI Compass</span>
+      <span id="bannerText">Бібліотека перевірених AI сервісів для маркетингу, автоматизації та аналітики.</span>
     </div>
-    <div class="card">
-      <svg id="stage" viewBox="0 0 1100 760" aria-label="Mind map canvas"></svg>
-    </div>
-    <p style="color:#4b5563; font-size:12px; margin-top:10px;">
-      Клік по категорії — розкрити сервіси. Наведіть — опис і посилання. / Click category to expand; hover a service for description & link.
-    </p>
   </div>
+
+  <header class="hero">
+    <div class="wrap hero-inner">
+      <span class="hero-label">AI Compass</span>
+      <h1 id="heroTitle" class="hero-title">Ваш компас у світі ШІ сервісів</h1>
+      <p id="heroSubtitle" class="hero-subtitle">Відкривайте перевірені платформи для бізнесу, творчості й автоматизації.</p>
+      <p id="heroDescription" class="hero-description">
+        Перемикайте мову, обирайте категорію та натискайте на сервіси, щоб швидко знайти потрібний інструмент і перейти на його сайт.
+      </p>
+    </div>
+  </header>
+
+  <main>
+    <div class="wrap main-content">
+      <div class="bar">
+        <h2 id="mapHeading" class="map-heading">Мапа категорій AI‑сервісів</h2>
+        <div class="language-toggle">
+          <button id="uaBtn" class="btn active">UA</button>
+          <button id="enBtn" class="btn">EN</button>
+        </div>
+      </div>
+      <div class="card">
+        <svg id="stage" viewBox="0 0 1100 760" aria-label="Mind map canvas"></svg>
+      </div>
+      <p id="infoNote" class="info-note">
+        Іконки поруч із назвами допомагають швидко зорієнтуватися. Клікніть категорію, щоб побачити сервіси. Наведіть курсор — опис та посилання.
+      </p>
+    </div>
+  </main>
+
+  <footer class="site-footer">
+    <div class="wrap footer-inner">
+      <span class="footer-title">Dmytro Klevakin</span>
+      <span id="footerRights">All rights reserved · 2024</span>
+      <span id="footerTagline">Crafted to help you explore and compare AI solutions with confidence.</span>
+    </div>
+  </footer>
 
   <script>
     const DATA = {
@@ -63,6 +302,31 @@
               name: "Microsoft Copilot",
               href: "https://copilot.microsoft.com/",
               desc: "Вбудований у Word, Excel, Outlook, PowerPoint та Teams для корпоративних сценаріїв. Автоматично створює звіти, пропозиції й відповіді на листи на основі ваших файлів. Підсумовує зустрічі, виокремлює ризики і формує наступні кроки для команди. Спирається на безпеку й контроль Microsoft 365.",
+            },
+            {
+              name: "Perplexity AI",
+              href: "https://www.perplexity.ai/",
+              desc: "Пошуковий асистент із живими посиланнями на джерела. Поєднує AI-відповіді з веб-результатами, допомагає досліджувати теми, створювати резюме та списки ресурсів. Має мобільні застосунки, колекції і спільні простори для команд.",
+            },
+            {
+              name: "Mistral Le Chat",
+              href: "https://chat.mistral.ai/",
+              desc: "Європейський чат на моделях Mistral, який підтримує кілька мов і зосереджений на приватності. Має експертні режими для коду, аналізу документів і перекладу. Пропонує API та корпоративний контроль даних.",
+            },
+            {
+              name: "Pi by Inflection",
+              href: "https://pi.ai/",
+              desc: "Персональний співрозмовник, що веде підтримувальні діалоги й допомагає знаходити ідеї. Орієнтований на емпатичну комунікацію, пропонує нагадування, мозкові штурми й короткі пояснення. Доступний у застосунках та через SMS.",
+            },
+            {
+              name: "You.com",
+              href: "https://you.com/",
+              desc: "AI-пошуковик із чат-помічником, що підсумовує результати та показує посилання. Пропонує режими для коду, наукових публікацій і генерації зображень. Підтримує швидкі дії прямо зі сторінки результатів.",
+            },
+            {
+              name: "Character.AI",
+              href: "https://beta.character.ai/",
+              desc: "Платформа для створення власних AI-персонажів і сценарних діалогів. Дозволяє тренувати ботів на власних описах, вести групові чати та ділитися персонажами з командою. Підходить для мозкових штурмів, навчання та рольових сценаріїв.",
             },
           ],
         },
@@ -95,6 +359,26 @@
               href: "https://www.adobe.com/products/firefly.html",
               desc: "Пропонує генеративні інструменти, інтегровані в Photoshop, Illustrator і Express. Дозволяє створювати зображення, текстури й ефекти за текстовими підказками. Підтримує Generative Fill для контекстного редагування та точних правок. Має ліцензований датасет, тож контент підходить для комерційного використання.",
             },
+            {
+              name: "Ideogram AI",
+              href: "https://ideogram.ai/",
+              desc: "Генерує зображення з точним відображенням тексту й логотипів. Допомагає створювати постери, мерч та рекламні візуали із збереженням типографіки. Має спільноту промптів і колекції для брендів.",
+            },
+            {
+              name: "Playground AI",
+              href: "https://playground.com/",
+              desc: "Веб-студія, що поєднує генерацію й редагування. Підтримує кілька моделей, маскування, стилі та спільну роботу. Дозволяє швидко створювати набори зображень і експортувати варіації у високій роздільності.",
+            },
+            {
+              name: "DALL·E",
+              href: "https://openai.com/dall-e-3",
+              desc: "Модель від OpenAI для створення детальних ілюстрацій та варіацій брендованих зображень. Підтримує точне керування стилем, пропорціями та побудовою композиції. Інтегрується в ChatGPT і має інструменти для оперативного редагування результатів.",
+            },
+            {
+              name: "Krea AI",
+              href: "https://www.krea.ai/",
+              desc: "Платформа для генерації дизайнів, патернів і moodboard-колажів у режимі реального часу. Пропонує бібліотеку стилів, фільтри промптів та контроль кольорів. Дозволяє командам працювати спільно та експортувати варіації без додаткового софту.",
+            },
           ],
         },
         {
@@ -126,6 +410,31 @@
               href: "https://www.opus.pro/",
               desc: "Спеціалізується на швидкому створенні вертикальних кліпів для соцмереж. Розпізнає найцікавіші фрагменти з довгих відео й розставляє акценти. Генерує субтитри, емодзі та заголовки для утримання уваги. Має аналітику A/B і рекомендації щодо часу публікації.",
             },
+            {
+              name: "CapCut",
+              href: "https://www.capcut.com/",
+              desc: "Редактор для швидкого створення вертикальних відео та кліпів. Має шаблони трендів, авто-субтитри і бібліотеку ефектів. AI функції вирізають фони, змінюють голос і покращують якість. Ідеально підходить для TikTok, Reels і YouTube Shorts.",
+            },
+            {
+              name: "Descript",
+              href: "https://www.descript.com/",
+              desc: "Редактор, що перетворює аудіо та відео в текст для миттєвого монтажу. Автоматично видаляє паузи, очищує звук, додає титри та генерує AI-голоси. Підтримує спільну роботу й публікацію роликів у кілька кліків.",
+            },
+            {
+              name: "Lumen5",
+              href: "https://lumen5.com/",
+              desc: "Онлайн-студія, яка перетворює статті, вебінари та блоги у відео з субтитрами. AI підбирає кадри, музику та ритм монтажу відповідно до сценарію. Пропонує бібліотеку брендованих шаблонів і формати для соцмереж.",
+            },
+            {
+              name: "Rephrase.ai",
+              href: "https://www.rephrase.ai/",
+              desc: "Сервіс для створення персоналізованих відео з цифровими аватарами. Генерує індивідуальні звернення для продажів, онбордингу чи підтримки клієнтів. Має API для масових кампаній та інтеграції з CRM-платформами.",
+            },
+            {
+              name: "Fliki",
+              href: "https://fliki.ai/",
+              desc: "Платформа для створення відео з тексту, статей чи твітів. Має велику бібліотеку голосів, субтитрів і шаблонів сцен. Генерує ролики кількома мовами та одразу пропонує формати для соцмереж.",
+            },
           ],
         },
         {
@@ -133,29 +442,59 @@
           color: "#db2777",
           items: [
             {
-              name: "Zapier",
-              href: "https://zapier.com/",
-              desc: "Дозволяє поєднувати тисячі SaaS-сервісів без коду. Автоматизує повторювані дії між CRM, маркетингом, фінансами та підтримкою. Пропонує готові шаблони для запуску роботів за хвилини. Має вбудовані AI-доповнення для обробки тексту та ухвалення рішень.",
+              group: "Інтеграції та робочі потоки",
+              items: [
+                {
+                  name: "Zapier",
+                  href: "https://zapier.com/",
+                  desc: "Дозволяє поєднувати тисячі SaaS-сервісів без коду. Автоматизує повторювані дії між CRM, маркетингом, фінансами та підтримкою. Пропонує готові шаблони для запуску роботів за хвилини. Має вбудовані AI-доповнення для обробки тексту та ухвалення рішень.",
+                },
+                {
+                  name: "Make",
+                  href: "https://www.make.com/",
+                  desc: "Візуальний конструктор сценаріїв із гнучкими умовами та паралельними гілками. Підтримує розгалужену логіку, цикли й роботу з великими масивами даних. Дає змогу будувати інтеграції між внутрішніми системами й API. Містить AI-модулі для класифікації й генерації контенту в процесі.",
+                },
+                {
+                  name: "n8n",
+                  href: "https://n8n.io/",
+                  desc: "Open-source платформа для автоматизації з можливістю самостійного хостингу. Надає контролю над даними та розширеннями через JavaScript. Підтримує складні робочі процеси, вебхуки і кастомні ноди. Активна спільнота створює готові фрагменти для AI-інтеграцій.",
+                },
+                {
+                  name: "Workato",
+                  href: "https://www.workato.com/",
+                  desc: "Платформа iPaaS для інтеграції корпоративних систем. Поєднує додатки, бази даних і чат-боти, автоматизує процеси з AI-підказками. Підтримує складні правила, контроль доступу та моніторинг виконання.",
+                },
+              ],
             },
             {
-              name: "Make",
-              href: "https://www.make.com/",
-              desc: "Візуальний конструктор сценаріїв із гнучкими умовами та паралельними гілками. Підтримує розгалужену логіку, цикли й роботу з великими масивами даних. Дає змогу будувати інтеграції між внутрішніми системами й API. Містить AI-модулі для класифікації й генерації контенту в процесі.",
+              group: "RPA та корпоративна автоматизація",
+              items: [
+                {
+                  name: "UiPath",
+                  href: "https://www.uipath.com/",
+                  desc: "Рішення для роботизованої автоматизації бізнес-процесів на рівні підприємства. Захоплює дії користувача, аналізує документи та запускає цифрових роботів. Має Studio, Orchestrator і Test Suite для повного циклу автоматизації. Вбудовані AI-модулі допомагають обробляти зображення, тексти й пошту.",
+                },
+                {
+                  name: "Power Automate",
+                  href: "https://powerautomate.microsoft.com/",
+                  desc: "Хмарна платформа від Microsoft для автоматизації робочих процесів і RPA. Інтегрується з екосистемою Microsoft 365, Dynamics, Azure та сторонніми сервісами. Дозволяє створювати боти, які запускають дії за подіями або розкладом. Copilot допомагає будувати потоки природною мовою.",
+                },
+              ],
             },
             {
-              name: "n8n",
-              href: "https://n8n.io/",
-              desc: "Open-source платформа для автоматизації з можливістю самостійного хостингу. Надає контролю над даними та розширеннями через JavaScript. Підтримує складні робочі процеси, вебхуки і кастомні ноди. Активна спільнота створює готові фрагменти для AI-інтеграцій.",
+              name: "Bardeen",
+              href: "https://www.bardeen.ai/",
+              desc: "Розширення для браузера, що автоматизує ручні завдання між вебдодатками. Запускає скрейпінг, заповнення форм, створення задач і CRM-записів за один клік. Має готові плейбуки та AI-помічника для побудови сценаріїв.",
             },
             {
-              name: "UiPath",
-              href: "https://www.uipath.com/",
-              desc: "Рішення для роботизованої автоматизації бізнес-процесів на рівні підприємства. Захоплює дії користувача, аналізує документи та запускає цифрових роботів. Має Studio, Orchestrator і Test Suite для повного циклу автоматизації. Вбудовані AI-модулі допомагають обробляти зображення, тексти й пошту.",
+              name: "Levity",
+              href: "https://www.levity.ai/",
+              desc: "No-code платформа для автоматизації робочих процесів за допомогою власних AI-класифікаторів. Навчайте моделі на листах, зображеннях чи формах, щоб автоматично категоризувати запити й запускати дії. Інтегрується зі Slack, Gmail, Zendesk та іншими сервісами без коду.",
             },
             {
-              name: "Power Automate",
-              href: "https://powerautomate.microsoft.com/",
-              desc: "Хмарна платформа від Microsoft для автоматизації робочих процесів і RPA. Інтегрується з екосистемою Microsoft 365, Dynamics, Azure та сторонніми сервісами. Дозволяє створювати боти, які запускають дії за подіями або розкладом. Copilot допомагає будувати потоки природною мовою.",
+              name: "Axiom.ai",
+              href: "https://axiom.ai/",
+              desc: "Розширення для автоматизації роботи в браузері без програмування. Запускає скрейпінг, заповнення форм і повторювані дії у вебзастосунках. Підтримує планування запусків, взаємодію з Google Sheets та API для побудови власних цифрових асистентів.",
             },
           ],
         },
@@ -188,6 +527,21 @@
               href: "https://www.evolv.ai/",
               desc: "Платформа експериментів і персоналізації цифрових продуктів. Використовує AI, щоб тестувати сотні варіацій контенту й UX одночасно. Автоматично оптимізує досвід під сегменти аудиторії. Надає глибоку аналітику впливу на конверсії та дохід.",
             },
+            {
+              name: "Mindsmith",
+              href: "https://www.mindsmith.com/",
+              desc: "Платформа мікронавчання з AI-генерацією уроків. Допомагає експертам швидко створювати інтерактивні модулі, флеш-карти та квізи. Відстежує прогрес слухачів і автоматично оновлює контент за фідбеком.",
+            },
+            {
+              name: "Sana AI",
+              href: "https://www.sana.ai/",
+              desc: "Корпоративна система знань із пошуком, який розуміє природну мову. Об'єднує документи, відео й FAQ в єдиній базі, формує навчальні плейлісти та відповідає на питання співробітників. Має інтеграції з робочими інструментами та аналітику.",
+            },
+            {
+              name: "Workera",
+              href: "https://www.workera.ai/",
+              desc: "Платформа оцінювання навичок із генеративними підказками. Аналізує прогалини в знаннях, формує персональні навчальні плани та пропонує контент від партнерських провайдерів. Надає HR-командам глибоку аналітику й інтегрується з LMS.",
+            },
           ],
         },
         {
@@ -195,39 +549,69 @@
           color: "#0ea5e9",
           items: [
             {
-              name: "CapCut",
-              href: "https://www.capcut.com/",
-              desc: "Редактор для швидкого створення вертикальних відео та кліпів. Має шаблони трендів, авто-субтитри і бібліотеку ефектів. AI функції вирізають фони, змінюють голос і покращують якість. Ідеально підходить для TikTok, Reels і YouTube Shorts.",
+              group: "Відео та кліпи",
+              items: [
+                {
+                  name: "CapCut",
+                  href: "https://www.capcut.com/",
+                  desc: "Редактор для швидкого створення вертикальних відео та кліпів. Має шаблони трендів, авто-субтитри і бібліотеку ефектів. AI функції вирізають фони, змінюють голос і покращують якість. Ідеально підходить для TikTok, Reels і YouTube Shorts.",
+                },
+                {
+                  name: "VEED.io",
+                  href: "https://www.veed.io/",
+                  desc: "Онлайн-студія для монтажу й субтитрування відео. Підтримує запис екрана, подкастів і співпрацю в команді. AI-алгоритми автоматично розставляють субтитри, очищують звук і перекладають. Має шаблони для вебінарів, реклами та курсів.",
+                },
+              ],
             },
             {
-              name: "VEED.io",
-              href: "https://www.veed.io/",
-              desc: "Онлайн-студія для монтажу й субтитрування відео. Підтримує запис екрана, подкастів і співпрацю в команді. AI-алгоритми автоматично розставляють субтитри, очищують звук і перекладають. Має шаблони для вебінарів, реклами та курсів.",
+              group: "Контент і копірайтинг",
+              items: [
+                {
+                  name: "Copy.ai",
+                  href: "https://www.copy.ai/",
+                  desc: "Сервіс для генерації маркетингових текстів і брифів. Дозволяє створювати варіанти рекламних оголошень, описів продуктів і листів. Підтримує бібліотеки тонів, персон і кампаній. Має робочі процеси для автоматичного створення контенту з даних.",
+                },
+                {
+                  name: "Jasper",
+                  href: "https://www.jasper.ai/",
+                  desc: "AI-помічник для команд контент-маркетингу. Пропонує бренд-голос, стильові гіди і спільні проєкти. Генерує статті, лендінги, сценарії відео й SEO-брифи. Інтегрується з CMS та має аналітику продуктивності контенту.",
+                },
+                {
+                  name: "Writesonic",
+                  href: "https://writesonic.com/",
+                  desc: "AI-платформа для копірайтингу, реклами та SEO. Генерує статті, описи товарів, лендінги й чат-ботів із урахуванням голосу бренду. Має редактор із режимом перевірки фактів та інтеграції з WordPress і HubSpot.",
+                },
+                {
+                  name: "Notion AI",
+                  href: "https://www.notion.so/product/ai",
+                  desc: "Вбудований у Notion для створення документів, баз знань і планів. Допомагає структурувати зустрічі, резюмувати нотатки та генерувати задачі. Може трансформувати тексти в списки, таблиці або OKR. Підтримує командну роботу з правами доступу та шаблонами.",
+                },
+                {
+                  name: "Predis.ai",
+                  href: "https://predis.ai/",
+                  desc: "AI-помічник для створення постів у соцмережах і міні-кампаній. Аналізує конкурентів, підбирає теми, хештеги та візуальні макети. Формує календар публікацій і генерує зображення з текстами під тон вашого бренду.",
+                },
+              ],
             },
             {
-              name: "Copy.ai",
-              href: "https://www.copy.ai/",
-              desc: "Сервіс для генерації маркетингових текстів і брифів. Дозволяє створювати варіанти рекламних оголошень, описів продуктів і листів. Підтримує бібліотеки тонів, персон і кампаній. Має робочі процеси для автоматичного створення контенту з даних.",
-            },
-            {
-              name: "Jasper",
-              href: "https://www.jasper.ai/",
-              desc: "AI-помічник для команд контент-маркетингу. Пропонує бренд-голос, стильові гіди і спільні проєкти. Генерує статті, лендінги, сценарії відео й SEO-брифи. Інтегрується з CMS та має аналітику продуктивності контенту.",
-            },
-            {
-              name: "Notion AI",
-              href: "https://www.notion.so/product/ai",
-              desc: "Вбудований у Notion для створення документів, баз знань і планів. Допомагає структурувати зустрічі, резюмувати нотатки та генерувати задачі. Може трансформувати тексти в списки, таблиці або OKR. Підтримує командну роботу з правами доступу та шаблонами.",
-            },
-            {
-              name: "Tidio",
-              href: "https://www.tidio.com/",
-              desc: "Платформа живого чату з AI-ботами для продажів і підтримки. Автоматично відповідає на поширені питання та передає лідів менеджерам. Аналізує поведінку відвідувачів і показує персональні пропозиції. Має сценарії для email, месенджерів і інтеграції з CRM.",
-            },
-            {
-              name: "ManyChat",
-              href: "https://www.manychat.com/",
-              desc: "Конструктор чат-ботів для Instagram, Facebook і WhatsApp. Дозволяє будувати воронки з автоповідомленнями та AI-відповідями. Сегментує аудиторію, запускає розсилки й опитування. Інтегрується з Shopify, HubSpot та іншими маркетинговими інструментами.",
+              group: "SMM та чат-боти",
+              items: [
+                {
+                  name: "Tidio",
+                  href: "https://www.tidio.com/",
+                  desc: "Платформа живого чату з AI-ботами для продажів і підтримки. Автоматично відповідає на поширені питання та передає лідів менеджерам. Аналізує поведінку відвідувачів і показує персональні пропозиції. Має сценарії для email, месенджерів і інтеграції з CRM.",
+                },
+                {
+                  name: "ManyChat",
+                  href: "https://www.manychat.com/",
+                  desc: "Конструктор чат-ботів для Instagram, Facebook і WhatsApp. Дозволяє будувати воронки з автоповідомленнями та AI-відповідями. Сегментує аудиторію, запускає розсилки й опитування. Інтегрується з Shopify, HubSpot та іншими маркетинговими інструментами.",
+                },
+                {
+                  name: "Lately AI",
+                  href: "https://www.lately.ai/",
+                  desc: "Інструмент для переробки довгого контенту в пости для соцмереж. Аналізує історію кампаній, щоб підібрати тон і ключові повідомлення. Автоматично генерує календар публікацій і A/B варіанти.",
+                },
+              ],
             },
           ],
         },
@@ -259,6 +643,21 @@
               name: "Crux",
               href: "https://www.cruxinformatics.com/",
               desc: "Платформа для управління корпоративними даними та їх доставки в аналітичні системи. Автоматизує збір із зовнішніх джерел, очищення та нормалізацію. Підтримує готові конектори до фінансових і альтернативних датасетів. Використовує AI, щоб контролювати якість і повноту даних.",
+            },
+            {
+              name: "Tellius",
+              href: "https://www.tellius.com/",
+              desc: "Платформа доповненої аналітики, що відповідає на питання природною мовою. Дозволяє знаходити драйвери метрик, запускати сценарії what-if і будувати дашборди без коду. Має вбудовані моделі ML для прогнозування.",
+            },
+            {
+              name: "ThoughtSpot",
+              href: "https://www.thoughtspot.com/",
+              desc: "Платформа пошукової аналітики з AI-підказками. Дозволяє ставити запитання природною мовою, миттєво будувати візуалізації та знаходити тренди. Підтримує спільну роботу, вбудовування панелей і підключення до хмарних сховищ даних.",
+            },
+            {
+              name: "Obviously AI",
+              href: "https://www.obviously.ai/",
+              desc: "Сервіс для no-code прогнозної аналітики. Користувачі завантажують дані, а AI будує моделі, оцінює точність і пояснює вплив змінних. Підходить для швидких бізнес-гіпотез та експериментів.",
             },
           ],
         },
@@ -306,6 +705,16 @@
               href: "https://www.fashwell.com/",
               desc: "Рішення для fashion-ретейлу з візуальним пошуком і рекомендаціями. Аналізує каталоги, фото користувачів та тренди. Підбирає товари за стилем, кольором і фасоном у режимі реального часу. Підвищує конверсію й середній чек у онлайн-магазинах.",
             },
+            {
+              name: "Corti",
+              href: "https://www.corti.ai/",
+              desc: "AI-коуч для контакт-центрів і служб підтримки. Прослуховує дзвінки в реальному часі, підказує наступні кроки і фіксує ключові дані у CRM. Допомагає прискорити обробку звернень та підвищити якість сервісу.",
+            },
+            {
+              name: "Viz.ai",
+              href: "https://www.viz.ai/",
+              desc: "Медична платформа для раннього виявлення інсультів і серцевих подій. Аналізує томографію, сповіщає лікарів і координує команди у хвилини. Інтегрується з лікарняними системами та забезпечує відповідність регуляціям.",
+            },
           ],
         },
       ],
@@ -333,6 +742,31 @@
               name: "Microsoft Copilot",
               href: "https://copilot.microsoft.com/",
               desc: "Embedded across Word, Excel, Outlook, PowerPoint, and Teams for enterprise use. Drafts reports, proposals, and replies by relying on your files. Recaps meetings, surfaces risks, and suggests next steps for the team. Leverages Microsoft 365 security and governance.",
+            },
+            {
+              name: "Perplexity AI",
+              href: "https://www.perplexity.ai/",
+              desc: "AI-native search assistant with cited sources. Blends conversational answers with live web results, summarises topics, and recommends follow-up questions and reading lists. Offers mobile apps, collections, and shared workspaces for teams.",
+            },
+            {
+              name: "Mistral Le Chat",
+              href: "https://chat.mistral.ai/",
+              desc: "European chat experience powered by Mistral models with privacy controls. Supports multiple languages, expert modes for code, document analysis, and translation. Provides an API and enterprise governance for data-sensitive use cases.",
+            },
+            {
+              name: "Pi by Inflection",
+              href: "https://pi.ai/",
+              desc: "Personal AI companion focused on thoughtful, supportive conversations. Helps brainstorm ideas, plan next steps, and learn new topics with an empathetic tone. Available across apps, SMS, and voice integrations.",
+            },
+            {
+              name: "You.com",
+              href: "https://you.com/",
+              desc: "AI search engine with a chat assistant that summarizes results and surfaces citations. Offers modes for coding, scholarly research, and image generation. Supports quick actions straight from the results page.",
+            },
+            {
+              name: "Character.AI",
+              href: "https://beta.character.ai/",
+              desc: "Platform for creating custom AI characters and role-play dialogues. Train bots with personality briefs, host group chats, and share characters with teammates. Useful for brainstorming, learning, and simulation scenarios.",
             },
           ],
         },
@@ -365,6 +799,26 @@
               href: "https://www.adobe.com/products/firefly.html",
               desc: "Brings generative tools into Photoshop, Illustrator, and Express. Creates images, textures, and effects from textual prompts. Generative Fill enables context-aware edits and precise refinements. Trained on licensed datasets so outputs are safe for commercial use.",
             },
+            {
+              name: "Ideogram AI",
+              href: "https://ideogram.ai/",
+              desc: "Creates images with crisp typography and logo fidelity. Ideal for posters, merch, and ad visuals where text accuracy matters. Includes prompt community features and brand-specific collections.",
+            },
+            {
+              name: "Playground AI",
+              href: "https://playground.com/",
+              desc: "Web studio that blends image generation and editing. Offers multiple models, masking tools, style presets, and collaboration features. Quickly exports galleries of variations in high resolution.",
+            },
+            {
+              name: "DALL·E",
+              href: "https://openai.com/dall-e-3",
+              desc: "OpenAI model for producing detailed illustrations and branded image variations. Delivers precise control over style, proportions, and scene composition. Integrates into ChatGPT with tools for rapid touch-ups and edits.",
+            },
+            {
+              name: "Krea AI",
+              href: "https://www.krea.ai/",
+              desc: "Real-time design platform for generating patterns, concepts, and moodboards. Includes a style library, prompt filters, and granular color control. Enables collaborative sessions and exports variations without extra software.",
+            },
           ],
         },
         {
@@ -396,6 +850,31 @@
               href: "https://www.opus.pro/",
               desc: "Specializes in fast vertical clips tailored for social media. Detects high-impact segments from long videos and highlights key hooks. Generates captions, emojis, and titles to maximize retention. Includes A/B analytics and recommendations for posting schedules.",
             },
+            {
+              name: "CapCut",
+              href: "https://www.capcut.com/",
+              desc: "Editor for rapid creation of vertical videos and social clips. Packs trending templates, auto captions, and an effects library. AI tools remove backgrounds, change voices, and upscale footage. Built for TikTok, Reels, and YouTube Shorts workflows.",
+            },
+            {
+              name: "Descript",
+              href: "https://www.descript.com/",
+              desc: "Turns audio and video into text for intuitive editing. Removes filler words, cleans audio, adds captions, and synthesizes realistic voices. Built for collaborative publishing workflows across podcast and video teams.",
+            },
+            {
+              name: "Lumen5",
+              href: "https://lumen5.com/",
+              desc: "Online studio that transforms articles, webinars, and blog posts into captioned videos. AI selects visuals, music, and pacing to match your script. Includes branded templates and ready-to-publish formats for social channels.",
+            },
+            {
+              name: "Rephrase.ai",
+              href: "https://www.rephrase.ai/",
+              desc: "Generates personalized videos with digital avatars tailored to each recipient. Perfect for sales, onboarding, and customer success messages. Offers an API for large-scale campaigns and CRM integrations.",
+            },
+            {
+              name: "Fliki",
+              href: "https://fliki.ai/",
+              desc: "Transforms text, articles, or tweets into ready-to-share videos. Features a library of lifelike voices, subtitles, and scene templates. Generates multilingual clips and exports social formats automatically.",
+            },
           ],
         },
         {
@@ -403,29 +882,59 @@
           color: "#db2777",
           items: [
             {
-              name: "Zapier",
-              href: "https://zapier.com/",
-              desc: "Connects thousands of SaaS tools without writing code. Automates repetitive workflows across CRM, marketing, finance, and support. Offers ready-made templates to launch automations in minutes. Built-in AI steps classify text, enrich data, and trigger decisions.",
+              group: "Integration platforms",
+              items: [
+                {
+                  name: "Zapier",
+                  href: "https://zapier.com/",
+                  desc: "Connects thousands of SaaS tools without writing code. Automates repetitive workflows across CRM, marketing, finance, and support. Offers ready-made templates to launch automations in minutes. Built-in AI steps classify text, enrich data, and trigger decisions.",
+                },
+                {
+                  name: "Make",
+                  href: "https://www.make.com/",
+                  desc: "Visual scenario builder with flexible conditions and parallel branches. Handles complex logic, loops, and bulk data operations. Bridges internal systems and APIs into unified flows. AI modules classify, summarize, and generate content mid-process.",
+                },
+                {
+                  name: "n8n",
+                  href: "https://n8n.io/",
+                  desc: "Open-source automation platform you can self-host. Gives full control over data, extensions, and JavaScript customizations. Orchestrates intricate workflows, webhooks, and custom nodes. A vibrant community shares ready-to-use snippets for AI integrations.",
+                },
+                {
+                  name: "Workato",
+                  href: "https://www.workato.com/",
+                  desc: "Enterprise iPaaS connecting apps, databases, and bots. Automates workflows with AI suggestions, governance controls, and reusable recipes. Handles complex logic, data mappings, and real-time monitoring.",
+                },
+              ],
             },
             {
-              name: "Make",
-              href: "https://www.make.com/",
-              desc: "Visual scenario builder with flexible conditions and parallel branches. Handles complex logic, loops, and bulk data operations. Bridges internal systems and APIs into unified flows. AI modules classify, summarize, and generate content mid-process.",
+              group: "RPA & digital workers",
+              items: [
+                {
+                  name: "UiPath",
+                  href: "https://www.uipath.com/",
+                  desc: "Enterprise-grade robotic process automation suite. Captures user actions, reads documents, and deploys digital workers. Studio, Orchestrator, and Test Suite cover the automation lifecycle. Built-in AI skills process images, text, and email at scale.",
+                },
+                {
+                  name: "Power Automate",
+                  href: "https://powerautomate.microsoft.com/",
+                  desc: "Microsoft’s cloud platform for workflow automation and RPA. Integrates deeply with Microsoft 365, Dynamics, Azure, and third-party services. Builds bots that trigger on events, schedules, or approvals. Copilot assists with designing flows using natural language.",
+                },
+              ],
             },
             {
-              name: "n8n",
-              href: "https://n8n.io/",
-              desc: "Open-source automation platform you can self-host. Gives full control over data, extensions, and JavaScript customizations. Orchestrates intricate workflows, webhooks, and custom nodes. A vibrant community shares ready-to-use snippets for AI integrations.",
+              name: "Bardeen",
+              href: "https://www.bardeen.ai/",
+              desc: "Browser automation co-pilot that removes repetitive web tasks. Scrapes data, fills forms, creates tasks, and updates CRMs with a click. Ships with ready-made playbooks and an AI helper to build new flows.",
             },
             {
-              name: "UiPath",
-              href: "https://www.uipath.com/",
-              desc: "Enterprise-grade robotic process automation suite. Captures user actions, reads documents, and deploys digital workers. Studio, Orchestrator, and Test Suite cover the automation lifecycle. Built-in AI skills process images, text, and email at scale.",
+              name: "Levity",
+              href: "https://www.levity.ai/",
+              desc: "No-code automation platform powered by custom AI classifiers. Train models on emails, images, or forms to categorize requests and trigger workflows automatically. Connects to Slack, Gmail, Zendesk, and more without writing code.",
             },
             {
-              name: "Power Automate",
-              href: "https://powerautomate.microsoft.com/",
-              desc: "Microsoft’s cloud platform for workflow automation and RPA. Integrates deeply with Microsoft 365, Dynamics, Azure, and third-party services. Builds bots that trigger on events, schedules, or approvals. Copilot assists with designing flows using natural language.",
+              name: "Axiom.ai",
+              href: "https://axiom.ai/",
+              desc: "Browser automation extension for teams who need repeatable web actions. Launch scrapers, form fills, and back-office routines without scripting. Supports scheduling, Google Sheets, and API calls to build digital assistants.",
             },
           ],
         },
@@ -458,6 +967,21 @@
               href: "https://www.evolv.ai/",
               desc: "Experimentation and personalization platform for digital products. Uses AI to test hundreds of content and UX variations simultaneously. Automatically tailors experiences to audience segments. Provides deep analytics on conversion and revenue impact.",
             },
+            {
+              name: "Mindsmith",
+              href: "https://www.mindsmith.com/",
+              desc: "Microlearning platform with AI-generated lessons. Lets subject matter experts build interactive modules, flashcards, and quizzes in minutes. Tracks learner progress and evolves content based on feedback.",
+            },
+            {
+              name: "Sana AI",
+              href: "https://www.sana.ai/",
+              desc: "Enterprise knowledge platform with natural-language answers. Centralizes docs, videos, and FAQs, generates learning playlists, and supports employees with instant responses. Integrates with daily tools and delivers actionable analytics.",
+            },
+            {
+              name: "Workera",
+              href: "https://www.workera.ai/",
+              desc: "Skills intelligence platform with AI-guided assessments. Diagnoses capability gaps, recommends personalized learning plans, and curates partner content automatically. Gives HR teams deep analytics and plugs into LMS ecosystems.",
+            },
           ],
         },
         {
@@ -465,39 +989,69 @@
           color: "#0ea5e9",
           items: [
             {
-              name: "CapCut",
-              href: "https://www.capcut.com/",
-              desc: "Editor for rapid creation of vertical videos and social clips. Packs trending templates, auto captions, and an effects library. AI tools remove backgrounds, change voices, and upscale footage. Built for TikTok, Reels, and YouTube Shorts workflows.",
+              group: "Video & clips",
+              items: [
+                {
+                  name: "CapCut",
+                  href: "https://www.capcut.com/",
+                  desc: "Editor for rapid creation of vertical videos and social clips. Packs trending templates, auto captions, and an effects library. AI tools remove backgrounds, change voices, and upscale footage. Built for TikTok, Reels, and YouTube Shorts workflows.",
+                },
+                {
+                  name: "VEED.io",
+                  href: "https://www.veed.io/",
+                  desc: "Online studio for video editing and captioning. Supports screen recording, podcast production, and team collaboration. AI transcribes, cleans audio, and translates subtitles. Templates cover webinars, ads, and course content.",
+                },
+              ],
             },
             {
-              name: "VEED.io",
-              href: "https://www.veed.io/",
-              desc: "Online studio for video editing and captioning. Supports screen recording, podcast production, and team collaboration. AI transcribes, cleans audio, and translates subtitles. Templates cover webinars, ads, and course content.",
+              group: "Content & copywriting",
+              items: [
+                {
+                  name: "Copy.ai",
+                  href: "https://www.copy.ai/",
+                  desc: "Generates marketing copy and creative briefs in seconds. Produces variations of ads, product descriptions, and outreach emails. Libraries store brand tones, personas, and campaign assets. Automated workflows build content directly from your data.",
+                },
+                {
+                  name: "Jasper",
+                  href: "https://www.jasper.ai/",
+                  desc: "AI assistant for content marketing teams. Provides brand voice, style guides, and collaborative projects. Writes articles, landing pages, scripts, and SEO briefs at scale. Integrates with CMS tools and reports on content performance.",
+                },
+                {
+                  name: "Writesonic",
+                  href: "https://writesonic.com/",
+                  desc: "AI writing suite for marketing copy, ads, and SEO. Produces articles, product descriptions, landing pages, and chatbots tuned to your brand voice. Includes fact-checking mode and integrations with WordPress and HubSpot.",
+                },
+                {
+                  name: "Notion AI",
+                  href: "https://www.notion.so/product/ai",
+                  desc: "Embedded in Notion to craft docs, knowledge bases, and plans. Structures meeting notes, summarizes research, and generates tasks. Transforms raw text into lists, tables, or OKRs instantly. Designed for collaborative work with permissions and templates.",
+                },
+                {
+                  name: "Predis.ai",
+                  href: "https://predis.ai/",
+                  desc: "AI assistant for social content campaigns. Analyzes competitors, recommends topics, hashtags, and visual layouts, and drafts captions in your brand voice. Builds posting calendars and auto-generates matching graphics.",
+                },
+              ],
             },
             {
-              name: "Copy.ai",
-              href: "https://www.copy.ai/",
-              desc: "Generates marketing copy and creative briefs in seconds. Produces variations of ads, product descriptions, and outreach emails. Libraries store brand tones, personas, and campaign assets. Automated workflows build content directly from your data.",
-            },
-            {
-              name: "Jasper",
-              href: "https://www.jasper.ai/",
-              desc: "AI assistant for content marketing teams. Provides brand voice, style guides, and collaborative projects. Writes articles, landing pages, scripts, and SEO briefs at scale. Integrates with CMS tools and reports on content performance.",
-            },
-            {
-              name: "Notion AI",
-              href: "https://www.notion.so/product/ai",
-              desc: "Embedded in Notion to craft docs, knowledge bases, and plans. Structures meeting notes, summarizes research, and generates tasks. Transforms raw text into lists, tables, or OKRs instantly. Designed for collaborative work with permissions and templates.",
-            },
-            {
-              name: "Tidio",
-              href: "https://www.tidio.com/",
-              desc: "Live chat platform with AI bots for sales and support. Answers repetitive questions and routes leads to agents automatically. Tracks visitor behavior to trigger personalized offers. Orchestrates email, messenger, and CRM integrations.",
-            },
-            {
-              name: "ManyChat",
-              href: "https://www.manychat.com/",
-              desc: "Chatbot builder for Instagram, Facebook, and WhatsApp. Designs funnels with autoresponders and AI-powered replies. Segments audiences, launches broadcasts, and runs surveys. Connects to Shopify, HubSpot, and other marketing stacks.",
+              group: "SMM & chatbots",
+              items: [
+                {
+                  name: "Tidio",
+                  href: "https://www.tidio.com/",
+                  desc: "Live chat platform with AI bots for sales and support. Answers repetitive questions and routes leads to agents automatically. Tracks visitor behavior to trigger personalized offers. Orchestrates email, messenger, and CRM integrations.",
+                },
+                {
+                  name: "ManyChat",
+                  href: "https://www.manychat.com/",
+                  desc: "Chatbot builder for Instagram, Facebook, and WhatsApp. Designs funnels with autoresponders and AI-powered replies. Segments audiences, launches broadcasts, and runs surveys. Connects to Shopify, HubSpot, and other marketing stacks.",
+                },
+                {
+                  name: "Lately AI",
+                  href: "https://www.lately.ai/",
+                  desc: "Repurposes long-form content into high-performing social posts. Learns from past campaigns to match tone and key messages. Automatically drafts publishing calendars and A/B variations.",
+                },
+              ],
             },
           ],
         },
@@ -529,6 +1083,21 @@
               name: "Crux",
               href: "https://www.cruxinformatics.com/",
               desc: "Data operations platform for sourcing and delivering enterprise data. Automates ingestion, cleaning, and normalization from external providers. Ships ready-made connectors for financial and alternative datasets. AI monitors data quality and completeness continuously.",
+            },
+            {
+              name: "Tellius",
+              href: "https://www.tellius.com/",
+              desc: "Augmented analytics that answers questions in natural language. Uncovers metric drivers, runs what-if scenarios, and builds dashboards without coding. Includes embedded ML models for forecasting.",
+            },
+            {
+              name: "ThoughtSpot",
+              href: "https://www.thoughtspot.com/",
+              desc: "Search-driven analytics platform with AI guidance. Ask questions in natural language, instantly generate charts, and surface trends. Supports collaboration, embedded dashboards, and connections to modern cloud data warehouses.",
+            },
+            {
+              name: "Obviously AI",
+              href: "https://www.obviously.ai/",
+              desc: "No-code predictive analytics for business teams. Upload data and let AI build models, measure accuracy, and explain the drivers. Ideal for rapid experimentation and operational decisions.",
             },
           ],
         },
@@ -576,10 +1145,115 @@
               href: "https://www.fashwell.com/",
               desc: "Visual search and recommendation engine for fashion retail. Analyzes catalogues, user photos, and trend data. Matches products by style, color, and fit in real time. Lifts conversion rates and basket size for online stores.",
             },
+            {
+              name: "Corti",
+              href: "https://www.corti.ai/",
+              desc: "AI coach for contact centers and emergency teams. Listens to calls in real time, suggests next best actions, and logs key details into CRMs. Improves response speed and quality assurance.",
+            },
+            {
+              name: "Viz.ai",
+              href: "https://www.viz.ai/",
+              desc: "Clinical AI platform for detecting strokes and cardiac events early. Analyzes imaging data, alerts specialists, and orchestrates care teams within minutes. Integrates with hospital systems and meets regulatory standards.",
+            },
           ],
         },
       ],
     };
+
+    const ICONS = {
+      'ChatGPT': '🧠',
+      'Claude': '🪶',
+      'Google Gemini': '✨',
+      'Microsoft Copilot': '🧭',
+      'Perplexity AI': '🔎',
+      'Mistral Le Chat': '🌬️',
+      'Pi by Inflection': '💬',
+      'You.com': '🔍',
+      'Character.AI': '🎭',
+      'Midjourney': '🎨',
+      'Stable Diffusion': '🌀',
+      'Leonardo AI': '🖌️',
+      'Canva AI': '🖼️',
+      'Adobe Firefly': '🔥',
+      'Ideogram AI': '🔤',
+      'Playground AI': '🛝',
+      'DALL·E': '🧩',
+      'Krea AI': '🌈',
+      'HeyGen': '🗣️',
+      'Synthesia': '🎬',
+      'Runway ML': '🎞️',
+      'Pictory': '🪄',
+      'OpusClip': '📱',
+      'Descript': '🎙️',
+      'Lumen5': '📽️',
+      'Rephrase.ai': '🗣️',
+      'Fliki': '🔊',
+      'Zapier': '⚡',
+      'Make': '🧩',
+      'n8n': '🪢',
+      'UiPath': '🏭',
+      'Power Automate': '🔁',
+      'Bardeen': '🛠️',
+      'Levity': '⚙️',
+      'Axiom.ai': '🧪',
+      'Workato': '🤝',
+      'Coursera': '🎓',
+      'Udemy': '📚',
+      'Docebo': '🏫',
+      'LearnWorlds': '🌐',
+      'Evolv AI': '📈',
+      'Mindsmith': '🧠',
+      'Sana AI': '💡',
+      'Workera': '🧬',
+      'CapCut': '✂️',
+      'VEED.io': '📼',
+      'Copy.ai': '✍️',
+      'Jasper': '🤖',
+      'Notion AI': '🗃️',
+      'Predis.ai': '📝',
+      'Tidio': '💬',
+      'ManyChat': '🤳',
+      'Writesonic': '🚀',
+      'Lately AI': '📊',
+      'Power BI': '📊',
+      'Tableau': '📈',
+      'MonkeyLearn': '🐒',
+      'Crayon': '🖍️',
+      'Crux': '🧱',
+      'Tellius': '🔮',
+      'ThoughtSpot': '🌟',
+      'Obviously AI': '🤔',
+      'Xero': '💼',
+      'QuickBooks': '🧾',
+      'AdCreative.ai': '🎯',
+      'Shopify AI': '🛒',
+      'Wix AI': '🏗️',
+      'Planner 5D': '🏠',
+      'Autodesk AI': '🏢',
+      'Fashwell AI': '👗',
+      'Corti': '📞',
+      'Viz.ai': '🩺',
+    };
+
+    const FALLBACK_ICON = '✨';
+
+    function formatLabel(name) {
+      const icon = ICONS[name] || FALLBACK_ICON;
+      return `${icon} ${name}`;
+    }
+
+    function isGroup(entry) {
+      return !!(entry && Array.isArray(entry.items) && entry.items.length);
+    }
+
+    function countLeafItems(entries) {
+      if (!Array.isArray(entries)) return 0;
+      return entries.reduce((total, entry) => {
+        if (!entry) return total;
+        if (isGroup(entry)) return total + entry.items.length;
+        return total + 1;
+      }, 0);
+    }
 
     // State
     let lang = localStorage.getItem('lang') || 'ua';
@@ -587,6 +1261,61 @@
     const stage = document.getElementById('stage');
     const uaBtn = document.getElementById('uaBtn');
     const enBtn = document.getElementById('enBtn');
+    const heroTitleEl = document.getElementById('heroTitle');
+    const heroSubtitleEl = document.getElementById('heroSubtitle');
+    const heroDescriptionEl = document.getElementById('heroDescription');
+    const mapHeadingEl = document.getElementById('mapHeading');
+    const bannerTextEl = document.getElementById('bannerText');
+    const infoNoteEl = document.getElementById('infoNote');
+    const footerRightsEl = document.getElementById('footerRights');
+    const footerTaglineEl = document.getElementById('footerTagline');
+
+    const COPY = {
+      heroTitle: {
+        ua: 'Ваш компас у світі ШІ сервісів',
+        en: 'Your compass through the AI service landscape',
+      },
+      heroSubtitle: {
+        ua: 'Відкривайте перевірені платформи для бізнесу, творчості й автоматизації.',
+        en: 'Discover trusted platforms for business, creativity, and automation.',
+      },
+      heroDescription: {
+        ua: 'Перемикайте мову, обирайте категорію та натискайте на сервіси, щоб швидко знайти потрібний інструмент і перейти на його сайт.',
+        en: 'Switch the language, pick a category, and click services to quickly find the right tool and jump to its official site.',
+      },
+      mapHeading: {
+        ua: 'Мапа категорій AI‑сервісів',
+        en: 'Map of AI service categories',
+      },
+      banner: {
+        ua: 'Бібліотека перевірених AI сервісів для маркетингу, автоматизації та аналітики.',
+        en: 'Curated AI tools for marketing, automation, and analytics teams.',
+      },
+      infoNote: {
+        ua: 'Іконки поруч із назвами допомагають швидко зорієнтуватися. Клікніть категорію, щоб побачити сервіси. Наведіть курсор — опис та посилання.',
+        en: 'Icons highlight each tool. Click a category to expand and hover any service to read the description and open the link.',
+      },
+      footerRights: {
+        ua: 'Усі права захищені · 2024',
+        en: 'All rights reserved · 2024',
+      },
+      footerTagline: {
+        ua: 'Створено, щоб допомогти досліджувати й порівнювати AI-рішення впевнено.',
+        en: 'Crafted to help you explore and compare AI solutions with confidence.',
+      },
+    };
+
+    function applyCopy() {
+      if (bannerTextEl) bannerTextEl.textContent = COPY.banner[lang];
+      if (heroTitleEl) heroTitleEl.textContent = COPY.heroTitle[lang];
+      if (heroSubtitleEl) heroSubtitleEl.textContent = COPY.heroSubtitle[lang];
+      if (heroDescriptionEl) heroDescriptionEl.textContent = COPY.heroDescription[lang];
+      if (mapHeadingEl) mapHeadingEl.textContent = COPY.mapHeading[lang];
+      if (infoNoteEl) infoNoteEl.textContent = COPY.infoNote[lang];
+      if (footerRightsEl) footerRightsEl.textContent = COPY.footerRights[lang];
+      if (footerTaglineEl) footerTaglineEl.textContent = COPY.footerTagline[lang];
+      document.documentElement.lang = lang === 'ua' ? 'uk' : 'en';
+    }
 
     function setLang(l) {
       lang = l;
@@ -594,6 +1323,7 @@
       uaBtn.classList.toggle('active', l==='ua');
       enBtn.classList.toggle('active', l==='en');
       expanded = null;
+      applyCopy();
       render();
     }
 
@@ -757,16 +1487,18 @@
       const leftCount = total - rightCount;
 
       const CATEGORY_GAP = 240;
-      const ITEM_GAP = 220;
+      const ITEM_GAP = 250;
+      const GROUP_GAP = 170;
       const BASE_SPACING = 110;
       const ITEM_SPACING = 64;
       const MARGIN_Y = 120;
-      const CANVAS_WIDTH = 1100;
+      const CANVAS_WIDTH = 1200;
       const MIN_HEIGHT = 680;
 
       const weights = data.map((cat, idx) => {
         if (expanded === idx) {
-          return Math.max(1.6, cat.items.length * 0.9);
+          const leafCount = countLeafItems(cat.items);
+          return Math.max(1.6, leafCount * 0.9);
         }
         return 1;
       });
@@ -811,7 +1543,7 @@
       layoutSide(0, rightCount, 'right');
       layoutSide(rightCount, leftCount, 'left');
 
-      const rootLabel = lang === 'ua' ? 'ШІ сервіси' : 'AI Services';
+      const rootLabel = 'AI Compass';
       const rootNode = createNode(nodesLayer, rootX, rootY, rootLabel, {
         fill: '#fff',
         stroke: '#111827',
@@ -882,39 +1614,109 @@
         highlight.setAttribute('stroke-dasharray', '8 12');
         connectorsLayer.appendChild(highlight);
 
-        const items = cat.items;
-        const itemCount = items.length;
-        if (itemCount) {
-          const branchHeight = ITEM_SPACING * (itemCount - 1);
-          const startY = node.y - branchHeight / 2;
-          const itemConnectors = group(connectorsLayer);
-          const itemLayer = group(nodesLayer);
+        const entries = Array.isArray(cat.items) ? cat.items : [];
+        const branches = [];
+        entries.forEach((entry) => {
+          if (isGroup(entry)) {
+            branches.push({ type: 'group', entry, size: entry.items.length });
+          } else if (entry && entry.name) {
+            branches.push({ type: 'item', entry, size: 1 });
+          }
+        });
 
-          items.forEach((item, idx) => {
-            const itemY = startY + idx * ITEM_SPACING;
-            const itemX = pos.side === 'right' ? pos.x + ITEM_GAP : pos.x - ITEM_GAP;
-            const itemNode = createNode(itemLayer, itemX, itemY, item.name, {
-              fill: '#fff',
-              stroke: cat.color,
-              sw: 1.5,
-              padX: 20,
-              padY: 12,
-              cls: 'small',
-            });
-            itemNode.group.style.cursor = 'pointer';
-            itemNode.group.addEventListener('mouseenter', () =>
-              showTip(itemX, itemY, item.name, item.desc, item.href)
-            );
-            itemNode.group.addEventListener('mouseleave', hideTip);
-            itemNode.group.addEventListener('click', () => window.open(item.href, '_blank'));
-            const startBranchX = pos.side === 'right' ? node.x + node.rx : node.x - node.rx;
-            const endBranchX = pos.side === 'right' ? itemX - itemNode.rx : itemX + itemNode.rx;
-            const ctrlBranchX = startBranchX + (endBranchX - startBranchX) * 0.6;
-            path(
-              itemConnectors,
-              `M ${startBranchX} ${node.y} C ${ctrlBranchX} ${node.y}, ${ctrlBranchX} ${itemY}, ${endBranchX} ${itemY}`,
-              { stroke: cat.color, sw: 1.6, op: 0.6 }
-            );
+        const totalLeaves = branches.reduce((sum, branch) => sum + branch.size, 0);
+        if (totalLeaves) {
+          const branchHeight = ITEM_SPACING * Math.max(0, totalLeaves - 1);
+          const startY = node.y - branchHeight / 2;
+          const branchConnectors = group(connectorsLayer);
+          const nestedConnectors = group(connectorsLayer);
+          const groupLayer = group(nodesLayer);
+          const leafLayer = group(nodesLayer);
+
+          let cursor = 0;
+          branches.forEach((branch) => {
+            const centerIndex = cursor + (branch.size - 1) / 2;
+            const branchY = startY + centerIndex * ITEM_SPACING;
+
+            if (branch.type === 'group') {
+              const groupX = pos.side === 'right' ? pos.x + GROUP_GAP : pos.x - GROUP_GAP;
+              const groupNode = createNode(groupLayer, groupX, branchY, branch.entry.group, {
+                fill: '#fff',
+                stroke: cat.color,
+                sw: 1.6,
+                padX: 20,
+                padY: 12,
+                cls: 'small',
+              });
+              const startBranchX = pos.side === 'right' ? node.x + node.rx : node.x - node.rx;
+              const endBranchX = pos.side === 'right' ? groupX - groupNode.rx : groupX + groupNode.rx;
+              const ctrlBranchX = startBranchX + (endBranchX - startBranchX) * 0.6;
+              path(
+                branchConnectors,
+                `M ${startBranchX} ${node.y} C ${ctrlBranchX} ${node.y}, ${ctrlBranchX} ${branchY}, ${endBranchX} ${branchY}`,
+                { stroke: cat.color, sw: 1.6, op: 0.6 }
+              );
+
+              branch.entry.items.forEach((svc, svcIdx) => {
+                const leafIndex = cursor + svcIdx;
+                const itemY = startY + leafIndex * ITEM_SPACING;
+                const itemX = pos.side === 'right' ? pos.x + ITEM_GAP : pos.x - ITEM_GAP;
+                const label = formatLabel(svc.name);
+                const itemNode = createNode(leafLayer, itemX, itemY, label, {
+                  fill: '#fff',
+                  stroke: cat.color,
+                  sw: 1.5,
+                  padX: 20,
+                  padY: 12,
+                  cls: 'small',
+                });
+                itemNode.group.style.cursor = 'pointer';
+                itemNode.group.setAttribute('aria-label', svc.name);
+                itemNode.group.addEventListener('mouseenter', () =>
+                  showTip(itemX, itemY, label, svc.desc, svc.href)
+                );
+                itemNode.group.addEventListener('mouseleave', hideTip);
+                itemNode.group.addEventListener('click', () => window.open(svc.href, '_blank'));
+                const startNestedX = pos.side === 'right' ? groupNode.x + groupNode.rx : groupNode.x - groupNode.rx;
+                const endNestedX = pos.side === 'right' ? itemX - itemNode.rx : itemX + itemNode.rx;
+                const ctrlNestedX = startNestedX + (endNestedX - startNestedX) * 0.6;
+                path(
+                  nestedConnectors,
+                  `M ${startNestedX} ${branchY} C ${ctrlNestedX} ${branchY}, ${ctrlNestedX} ${itemY}, ${endNestedX} ${itemY}`,
+                  { stroke: cat.color, sw: 1.4, op: 0.55 }
+                );
+              });
+            } else {
+              const svc = branch.entry;
+              const itemY = branchY;
+              const itemX = pos.side === 'right' ? pos.x + ITEM_GAP : pos.x - ITEM_GAP;
+              const label = formatLabel(svc.name);
+              const itemNode = createNode(leafLayer, itemX, itemY, label, {
+                fill: '#fff',
+                stroke: cat.color,
+                sw: 1.5,
+                padX: 20,
+                padY: 12,
+                cls: 'small',
+              });
+              itemNode.group.style.cursor = 'pointer';
+              itemNode.group.setAttribute('aria-label', svc.name);
+              itemNode.group.addEventListener('mouseenter', () =>
+                showTip(itemX, itemY, label, svc.desc, svc.href)
+              );
+              itemNode.group.addEventListener('mouseleave', hideTip);
+              itemNode.group.addEventListener('click', () => window.open(svc.href, '_blank'));
+              const startBranchX = pos.side === 'right' ? node.x + node.rx : node.x - node.rx;
+              const endBranchX = pos.side === 'right' ? itemX - itemNode.rx : itemX + itemNode.rx;
+              const ctrlBranchX = startBranchX + (endBranchX - startBranchX) * 0.6;
+              path(
+                branchConnectors,
+                `M ${startBranchX} ${node.y} C ${ctrlBranchX} ${node.y}, ${ctrlBranchX} ${itemY}, ${endBranchX} ${itemY}`,
+                { stroke: cat.color, sw: 1.6, op: 0.6 }
+              );
+            }
+
+            cursor += branch.size;
           });
         }
       }


### PR DESCRIPTION
## Summary
- add a bilingual announcement banner and dynamic footer/info copy so the landing section explains how to use AI Compass
- grow the Ukrainian and English datasets with new assistants, content, automation, learning, and analytics tools plus matching icons

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d0221db51c832cbfdb152f651a8e58