### PR TITLE
Translate documentation to English

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@ python3 -m http.server 8000
 ```
 /
 ├─ index.html            # Production single-file app (vanilla, no deps)
-├─ doc/                  # Документація та ADR
-│  ├─ index.md           # Керівництво користувача та підтримки
-│  ├─ Requirements.md    # Сукупність вимог
-│  ├─ Backlog.md         # Список покращень
-│  └─ adr/               # Архітектурні рішення
+├─ doc/                  # Documentation and ADRs
+│  ├─ index.md           # User and maintainer guide
+│  ├─ Requirements.md    # Consolidated requirements
+│  ├─ Backlog.md         # Improvement backlog
+│  └─ adr/               # Architecture decisions
 │     ├─ 0001-static-single-file-architecture.md
 │     ├─ 0002-adaptive-radial-layout.md
 │     ├─ 0003-curated-bilingual-catalog.md

--- a/doc/Backlog.md
+++ b/doc/Backlog.md
@@ -1,13 +1,12 @@
-# Backlog — AI Compass покращення
+# Backlog — AI Compass Improvements
 
-> **Примітка:** Створити або оновити задачі на GitHub Projects не вдалося в межах цього середовища. Будь ласка, додайте наведені нижче пункти на канбан-дошку вручну.
+> **Note:** Creating or updating GitHub Projects items is not possible in this environment. Please add the initiatives below to your Kanban board manually.
 
-| ID | Епік / тема | Опис ініціативи | Очікувана цінність | Пріоритет | Статус | Нотатки для GitHub Projects |
+| ID | Epic / Theme | Initiative Description | Expected Value | Priority | Status | Notes for GitHub Projects |
 | --- | --- | --- | --- | --- | --- | --- |
-| BL-01 | Пошук і фільтрація | Додати поле пошуку та фільтри за категоріями/типами сервісів, щоб швидко віднайти потрібний інструмент. | Скорочення часу на пошук сервісу, підвищення конверсії кліків. | High | Planned | Створити епік "Search" з задачами: UI, логіка фільтрації, UX-тести. |
-| BL-02 | Аналітика взаємодії | Інтегрувати простий збір статистики (наприклад, Plausible або GA4) для відстеження популярних категорій і сервісів. | Дає змогу пріоритезувати оновлення каталогу на основі даних. | Medium | Planned | Створити задачу з чек-листом: вибір платформи, оновлення політики, впровадження коду. |
-| BL-03 | Експорт каталогу | Реалізувати генерацію CSV/JSON з переліком сервісів для подальшої аналітики або імпорту в CRM. | Полегшує обмін даними з іншими системами та роботу консультантів. | Medium | Planned | Підготувати технічне рішення (кнопка експорту + формат файлів). |
-| BL-04 | Мобільна оптимізація | Уточнити відображення мапи на мобільних пристроях: масштабування, вертикальний скрол, читабельність тексту. | Покращує досвід користувачів, що відкривають сайт зі смартфонів. | High | In Review | Необхідно протестувати на реальних девайсах, задокументувати брейкпоінти. |
-| BL-05 | Контентні сценарії | Додати готові плейбуки використання (наприклад, "маркетингова кампанія" чи "автоматизація підтримки"). | Підвищує прикладну цінність і допомагає новачкам. | Medium | Planned | Розбити на підзадачі: дослідження, копірайтинг, дизайн секції. |
-| BL-06 | Підтримка третьої мови | Додати локалізацію, наприклад, польську або німецьку, з повним набором описів. | Розширює аудиторію і покращує експансію на нові ринки. | Low | Backlog | Підготувати мовне керівництво, залучити перекладача. |
-
+| BL-01 | Search & filtering | Add a search bar and filters by categories/service types to quickly find the desired tool. | Reduces time to locate a service and improves click-through rates. | High | Planned | Create a “Search” epic with tasks for UI, filtering logic, and UX testing. |
+| BL-02 | Interaction analytics | Integrate lightweight analytics (e.g., Plausible or GA4) to track popular categories and services. | Enables data-driven prioritization of catalog updates. | Medium | Planned | Create a task with a checklist: select a platform, update policy, implement tracking code. |
+| BL-03 | Catalog export | Generate CSV/JSON with the service list for analytics or CRM import. | Simplifies data sharing with other systems and consultants. | Medium | Planned | Prepare a technical plan (export button + file formats). |
+| BL-04 | Mobile optimization | Refine the map on mobile devices: scaling, vertical scroll, typography readability. | Improves the experience for users who access the site on smartphones. | High | In Review | Test on real devices and document breakpoints. |
+| BL-05 | Content playbooks | Add ready-made usage playbooks (e.g., “marketing campaign” or “support automation”). | Increases practical value and helps newcomers. | Medium | Planned | Break down into subtasks: research, copywriting, section design. |
+| BL-06 | Third-language support | Add another localization, such as Polish or German, with full descriptions. | Expands the audience and supports new markets. | Low | Backlog | Prepare a language guide and involve a translator. |

--- a/doc/Requirements.md
+++ b/doc/Requirements.md
@@ -1,54 +1,54 @@
 # Requirements — AI Compass
 
-## 1. Контекст та обсяг
-- **Опис продукту**: статична веб-мапа AI-сервісів для SMB, реалізована у файлі `index.html` без сторонніх залежностей.
-- **Межі системи**: сайт працює повністю на клієнті, не має бекенду і використовує лише відкриті посилання на зовнішні сервіси.
-- **Основні зацікавлені сторони**:
-  - Бізнес-власники та операційні менеджери, які приймають рішення щодо впровадження AI.
-  - Маркетингові та продуктові команди, що підбирають інструменти для конкретних кампаній.
-  - Команда підтримки сайту, яка оновлює перелік сервісів та підтримує локалізації.
+## 1. Context and Scope
+- **Product description:** a static web map of AI services for SMBs, implemented in `index.html` without third-party dependencies.
+- **System boundaries:** the site runs fully on the client, has no backend, and only links out to public external resources.
+- **Key stakeholders:**
+  - Business owners and operations managers who decide which AI tools to adopt.
+  - Marketing and product teams selecting tools for specific campaigns.
+  - The site maintenance team that updates the catalog and keeps localizations in sync.
 
-## 2. Функціональні вимоги
-### 2.1 Структура контенту
-1. Система повинна зберігати категорії, підкатегорії (групи) та сервіси у двох мовних масивах `ua` і `en`, щоб забезпечити синхронність перекладів.
-2. Кожен сервіс має містити назву, короткий опис і гіперпосилання на офіційний ресурс.
-3. Категорії та групи повинні мати унікальні кольори/назви для візуального відокремлення на мапі.
+## 2. Functional Requirements
+### 2.1 Content Structure
+1. The system must store categories, subcategories (groups), and services in two language arrays, `ua` and `en`, to keep translations aligned.
+2. Every service entry must include a name, short description, and hyperlink to the official resource.
+3. Categories and groups must have unique colors/titles to stay visually distinct on the map.
 
-### 2.2 Інтерактивність мапи
-4. Після завантаження сторінки користувач повинен бачити радіальну діаграму з центральним вузлом «AI Compass».
-5. Клік по категорії має розгортати/згортати перелік повʼязаних сервісів, а повторний клік — повертає стан за замовчуванням.
-6. Групи всередині категорій повинні згортатися/розгортатися незалежно від категорії, щоб масштабні списки залишались читабельними.
-7. Наведення на сервіс повинно показувати підказку з описом та посиланням; натискання відкриває офіційний сайт у новій вкладці.
-8. Іконки поруч із сервісами мають відображати тип інструменту й прискорювати пошук потрібного рішення.
+### 2.2 Map Interactivity
+4. After the page loads, the user must see a radial diagram with the “AI Compass” central node.
+5. Clicking a category must expand or collapse its related services; clicking again returns it to the default state.
+6. Groups inside categories must expand/collapse independently so long lists remain readable.
+7. Hovering over a service must show a tooltip with its description and link; clicking opens the official site in a new tab.
+8. Icons next to services must reflect the tool type and speed up scanning for the right solution.
 
-### 2.3 Локалізація та керування
-9. Користувач повинен мати змогу перемикати мову інтерфейсу між українською та англійською; вибір зберігається між сеансами через LocalStorage.
-10. Основні текстові блоки сторінки (банер, hero, примітки, футер) повинні автоматично оновлюватися відповідно до вибраної мови.
-11. Категорії на мапі мають реагувати на клавіатурні події `Enter` та `Space`, забезпечуючи базову доступність.
-12. Каталог має надавати інструкції щодо ручного оновлення даних для майбутніх редакторів контенту.
+### 2.3 Localization and Management
+9. Users must be able to switch the interface language between Ukrainian and English; the choice is persisted between sessions via LocalStorage.
+10. Core text blocks (banner, hero, notes, footer) must update automatically according to the selected language.
+11. Categories on the map must respond to keyboard `Enter` and `Space` events to provide basic accessibility.
+12. The catalog must document manual update instructions for future content editors.
 
-### 2.4 Деплоймент та документація
-13. Сайт повинен відкриватися напряму з файлової системи або через будь-який статичний хостинг без збірки.
-14. Документація до проєкту має розміщуватися в папці `/doc` і бути готовою до публікації через GitHub Pages.
-15. Потрібно надавати посилання на суміжні документи (ADR, backlog, вимоги) для зручної навігації команди.
+### 2.4 Deployment and Documentation
+13. The site must open directly from the file system or through any static hosting without a build step.
+14. Project documentation must live in the `/doc` folder and be ready for publication via GitHub Pages.
+15. Provide cross-links to related documents (ADR, backlog, requirements) to simplify navigation for the team.
 
-## 3. Нефункціональні вимоги
-| ID | Вимога | Тип |
+## 3. Non-functional Requirements
+| ID | Requirement | Type |
 | --- | --- | --- |
-| NF-1 | Рішення має працювати офлайн та без серверної частини. | Надійність / автономність |
-| NF-2 | Файл `index.html` повинен бути самодостатнім і не використовувати зовнішні бібліотеки для рендерингу мапи. | Архітектура |
-| NF-3 | Інтерфейс має бути читабельним на екранах від 1024px і зберігати працездатність на планшетах/мобільних пристроях. | Юзабіліті |
-| NF-4 | Усі тексти й дані повинні зберігатися в UTF-8 для підтримки української та англійської мов. | Сумісність |
-| NF-5 | Логіка взаємодії має залишатися зрозумілою без знання коду завдяки коментарям і документації. | Підтримуваність |
-| NF-6 | Розширення каталогу не повинно суттєво погіршувати продуктивність; розрахунки позицій виконуються клієнтом за O(n). | Продуктивність |
-| NF-7 | Код має дотримуватись принципів доступності: фокусовані елементи, aria-атрибути та контраст. | Доступність |
+| NF-1 | The solution must work offline and without a server component. | Reliability / Autonomy |
+| NF-2 | `index.html` must be self-contained and avoid external libraries for rendering the map. | Architecture |
+| NF-3 | The interface must be readable on screens from 1024px and remain usable on tablets/mobile devices. | Usability |
+| NF-4 | All text and data must be stored in UTF-8 to support Ukrainian and English languages. | Compatibility |
+| NF-5 | Interaction logic must stay understandable without reading the code thanks to comments and documentation. | Maintainability |
+| NF-6 | Catalog expansion must not significantly degrade performance; position calculations run on the client in O(n). | Performance |
+| NF-7 | The code must follow accessibility principles: focusable elements, ARIA attributes, and sufficient contrast. | Accessibility |
 
-## 4. Обмеження та припущення
-- Проєкт не зберігає користувацькі дані та не потребує політики конфіденційності.
-- Користувачам потрібен сучасний браузер з підтримкою SVG та LocalStorage.
-- Для аналітики відвідувань необхідно інтегрувати сторонні інструменти (відсутні у базовій версії).
+## 4. Constraints and Assumptions
+- The project does not store user data and does not require a privacy policy.
+- Users need a modern browser with SVG and LocalStorage support.
+- Traffic analytics requires integrating third-party tools (not included in the base version).
 
-## 5. Відкриті питання
-- Чи потрібна можливість імпорту/експорту каталогу у форматі JSON або Google Sheets.
-- Який процес рецензування нових сервісів перед публікацією та хто за нього відповідає.
-- Чи планується інтеграція з CRM/Slack для сповіщення про оновлення каталогу.
+## 5. Open Questions
+- Is there a need for JSON or Google Sheets import/export of the catalog?
+- What is the review process for new services before publication, and who owns it?
+- Should we integrate with CRM/Slack to notify stakeholders about catalog updates?

--- a/doc/adr/0001-static-single-file-architecture.md
+++ b/doc/adr/0001-static-single-file-architecture.md
@@ -1,20 +1,20 @@
-# ADR 0001: Статична односторінкова архітектура
+# ADR 0001: Static Single-File Architecture
 
-- **Статус:** Accepted
-- **Дата:** 2025-09-21
-- **Контекст:** вихідний репозиторій (`initial commit`, PR draft)
+- **Status:** Accepted
+- **Date:** 2025-09-21
+- **Context:** initial repository (`initial commit`, PR draft)
 
-## Контекст
-Перший реліз AI Compass мав забезпечити простий спосіб публікації каталогу AI-сервісів без бекенду та з мінімальною кількістю файлів. Команда хотіла, щоб рішення:
-- розгорталося на GitHub Pages чи Cloudflare Pages без CI/CD та Node.js;
-- працювало офлайн (достатньо зберегти сторінку);
-- було прозорим для нетехнічних редакторів, які можуть відкрити вихідний код та оновити дані вручну.
+## Context
+The first release of AI Compass needed a straightforward way to publish the AI service catalog without a backend and with as few files as possible. The team wanted a solution that:
+- could be deployed to GitHub Pages or Cloudflare Pages without CI/CD or Node.js;
+- worked offline (simply save the page);
+- remained transparent for non-technical editors who can open the source and update the data manually.
 
-## Рішення
-Обрано архітектуру "single-file app": увесь HTML, CSS, JavaScript та дані розміщено в `index.html`. Жодних сторонніх бібліотек чи пакетних менеджерів не використовується. Застосунок працює повністю на клієнті та рендерить SVG-графіку для мапи.
+## Decision
+We chose a “single-file app” architecture: all HTML, CSS, JavaScript, and data are placed inside `index.html`. No third-party libraries or package managers are used. The application runs entirely on the client and renders SVG graphics for the map.
 
-## Наслідки
-- ✅ Проєкт легко деплоїти на будь-який статичний хостинг і відкривати напряму з файлової системи.
-- ✅ Оновлення контенту можливе через просте редагування одного файлу без складної збірки.
-- ⚠️ Масштабування коду потребує акуратного структурування секцій в `index.html`, оскільки файл зростає в розмірах.
-- ⚠️ Відсутність збірки обмежує використання TypeScript/SCSS та модульної структури без додаткових інструментів.
+## Consequences
+- ✅ The project is easy to deploy on any static hosting and can even be opened directly from the file system.
+- ✅ Content updates require only editing one file without a build pipeline.
+- ⚠️ Scaling the code base demands careful structuring of sections within `index.html` as the file grows in size.
+- ⚠️ The lack of a build step limits the ability to use TypeScript/SCSS and modular organization without additional tooling.

--- a/doc/adr/0002-adaptive-radial-layout.md
+++ b/doc/adr/0002-adaptive-radial-layout.md
@@ -1,20 +1,20 @@
-# ADR 0002: Адаптивне радіальне компонування мапи
+# ADR 0002: Adaptive Radial Map Layout
 
-- **Статус:** Accepted
-- **Дата:** 2025-09-21
-- **Повʼязані PR:** #1 `codex/refactor-mind-map-l`
+- **Status:** Accepted
+- **Date:** 2025-09-21
+- **Related PRs:** #1 `codex/refactor-mind-map-l`
 
-## Контекст
-Початкове розміщення вузлів у мапі не враховувало різну кількість сервісів у категоріях. Через це деякі елементи перекривалися, а полотно мало фіксовану висоту й не масштабувалося під контент. Потрібно було забезпечити адаптивне компонування без сторонніх бібліотек для графів.
+## Context
+The initial node placement on the map did not account for different numbers of services per category. As a result, some elements overlapped and the canvas height was fixed, failing to scale with the content. We needed adaptive positioning without relying on external graph libraries.
 
-## Рішення
-- Розраховувати позиції категорій симетрично відносно центрального вузла та поділяти їх на ліву/праву півкулі.
-- Визначати вагу категорії залежно від кількості елементів (з урахуванням розкритих груп) і пропорційно розподіляти вертикальний простір.
-- Використовувати еліпси з динамічними радіусами навколо тексту, щоб довгі назви не обрізалися.
-- Генерувати з’єднувальні криві Безьє між центром і категоріями для плавної візуалізації звʼязків.
+## Decision
+- Compute category positions symmetrically around the central node, splitting them into left and right hemispheres.
+- Determine category weight based on the number of items (including expanded groups) and distribute vertical space proportionally.
+- Use ellipses with dynamic radii around text so long labels are not truncated.
+- Generate connecting Bézier curves between the center and categories for smooth visualization of relationships.
 
-## Наслідки
-- ✅ Мапа масштабуються під різні каталоги без перекриття елементів.
-- ✅ Гнучкі еліпси дозволяють легко додавати довгі назви категорій та сервісів.
-- ⚠️ Збільшилась складність клієнтської логіки; необхідні тести при зміні констант відступів.
-- ⚠️ Подальше ускладнення графа (наприклад, додавання третіх рівнів) вимагатиме додаткових алгоритмів розміщення.
+## Consequences
+- ✅ The map now scales to different catalogs without overlapping elements.
+- ✅ Flexible ellipses allow longer category and service names without clipping.
+- ⚠️ Client-side logic is more complex; we need regression tests when adjusting spacing constants.
+- ⚠️ Further graph complexity (such as third-level nodes) will require additional layout algorithms.

--- a/doc/adr/0003-curated-bilingual-catalog.md
+++ b/doc/adr/0003-curated-bilingual-catalog.md
@@ -1,21 +1,21 @@
-# ADR 0003: Курований двомовний каталог з іконками
+# ADR 0003: Curated Bilingual Catalog with Icons
 
-- **Статус:** Accepted
-- **Дата:** 2025-09-21
-- **Повʼязані PR:** #2 `codex/review-and-improve-services-categories`, #3 `codex/add-icons-to-ai-services`
+- **Status:** Accepted
+- **Date:** 2025-09-21
+- **Related PRs:** #2 `codex/review-and-improve-services-categories`, #3 `codex/add-icons-to-ai-services`
 
-## Контекст
-Початковий список сервісів був коротким і не відображав ключові сценарії використання для бізнесу. Крім того, відсутність іконок і додаткових описів ускладнювала швидке сканування списку та робила мапу менш інформативною. Команда прагнула покрити ширший стек AI-рішень та зробити каталог зручним як для україномовних, так і для англомовних користувачів.
+## Context
+The initial service list was short and failed to reflect key business use cases. The lack of icons and extended descriptions also made it harder to scan the map quickly and reduced its informational value. The team aimed to cover a broader range of AI solutions and make the catalog useful for both Ukrainian- and English-speaking audiences.
 
-## Рішення
-- Розширити `DATA` докладними описами сервісів українською й англійською мовами, синхронізуючи масиви `ua` та `en`.
-- Стандартизувати структуру категорій і груп, додати підгрупи (наприклад, "Відео та кліпи", "Контент і копірайтинг").
-- Додати словник `ICONS`, що відображає релевантні емодзі для популярних сервісів, і fallback-іконку ✨.
-- Оновити текстові блоки сторінки (банер, hero, нотатки, футер) для двомовного відображення.
+## Decision
+- Enrich the `DATA` object with detailed service descriptions in Ukrainian and English while keeping the `ua` and `en` arrays synchronized.
+- Standardize the structure of categories and groups, adding subgroups (for example, “Video & Clips” and “Content & Copywriting”).
+- Add an `ICONS` dictionary that maps popular services to relevant emoji and falls back to ✨ when undefined.
+- Update page text blocks (banner, hero, notes, footer) to support bilingual display.
 
-## Наслідки
-- ✅ Користувачі отримують контекст і сценарії використання без переходу на зовнішні сайти.
-- ✅ Білінгвальна підтримка робить продукт придатним для міжнародної аудиторії.
-- ✅ Іконки прискорюють візуальне сприйняття і допомагають відрізняти сервіси.
-- ⚠️ Збільшення обсягу даних потребує ретельного ревʼю перекладів при кожному оновленні.
-- ⚠️ Підтримка іконок вимагає синхронізації словника `ICONS` при додаванні нових сервісів.
+## Consequences
+- ✅ Users receive context and usage scenarios without leaving the site.
+- ✅ Bilingual support makes the product suitable for an international audience.
+- ✅ Icons speed up visual scanning and help differentiate services.
+- ⚠️ The larger dataset requires thorough translation review with each update.
+- ⚠️ Maintaining icons demands keeping the `ICONS` dictionary in sync when adding new services.

--- a/doc/adr/0004-collapsible-subcategories.md
+++ b/doc/adr/0004-collapsible-subcategories.md
@@ -1,20 +1,20 @@
-# ADR 0004: Розкривні підкатегорії та групи сервісів
+# ADR 0004: Collapsible Subcategories and Service Groups
 
-- **Статус:** Accepted
-- **Дата:** 2025-09-21
-- **Повʼязані PR:** #4 `codex/expand-subcategories-to-match-categories`
+- **Status:** Accepted
+- **Date:** 2025-09-21
+- **Related PRs:** #4 `codex/expand-subcategories-to-match-categories`
 
-## Контекст
-Зі збільшенням кількості сервісів у категоріях стало важко проглядати довгі списки — елементи виходили за межі екрана, а користувачі втрачали контекст. Потрібно було зберегти компактність мапи й одночасно дозволити заглиблюватися в потрібні блоки.
+## Context
+As the number of services grew within each category, long lists became hard to browse—items stretched beyond the viewport and users lost context. We needed to keep the map compact while allowing people to dive into specific sections.
 
-## Рішення
-- Запровадити структуру `group` → `items` для підгруп із власними заголовками.
-- Зберігати стан розгортання груп окремо для кожної мови та категорії через `Map` + `Set`, щоб перемикання мов не губило контекст.
-- Відображати групи як окремі вузли з можливістю відкриття/закриття клацанням і клавіатурою.
-- Перераховувати вагу категорій з урахуванням відкритих груп, щоб канва адаптувалася до нової висоти.
+## Decision
+- Introduce a `group` → `items` structure for subgroups with their own titles.
+- Store the expansion state of groups separately for each language and category via a `Map` + `Set` approach so language switching does not lose context.
+- Render groups as dedicated nodes that can be opened/closed via clicks and keyboard controls.
+- Recalculate category weights with the state of expanded groups to adjust the canvas height dynamically.
 
-## Наслідки
-- ✅ Користувачі бачать компактний огляд і розгортають лише потрібні підрозділи.
-- ✅ Архітектура даних дозволяє додавати гнучкі сценарії (наприклад, тематичні плейбуки).
-- ⚠️ Логіка підрахунку ваги категорії стала складнішою; потрібні unit-тести або smoke-тести при зміні структури.
-- ⚠️ Необхідно контролювати, щоб усі нові елементи мали унікальні назви груп для коректного кешування стану.
+## Consequences
+- ✅ Users get a concise overview and can expand only the sections they need.
+- ✅ The data architecture supports flexible scenarios such as thematic playbooks.
+- ⚠️ The category weight calculation logic is more complex; unit or smoke tests are recommended when the structure changes.
+- ⚠️ All new elements must have unique group names to ensure caching works correctly.

--- a/doc/index.md
+++ b/doc/index.md
@@ -1,60 +1,60 @@
-# AI Compass — документація користувача
+# AI Compass — User Guide
 
-## Опис проєкту
-AI Compass — це статичний вебсайт з інтерактивною мапою сервісів штучного інтелекту для малих та середніх бізнесів. Каталог зібрано у вигляді радіальної діаграми, де кожна категорія та сервіс візуально відображаються у зрозумілих зв'язках. Уся логіка та дані містяться в єдиному файлі `index.html`, тому рішення не потребує збірки, працює офлайн та легко хоститься на будь-якому статичному хостингу.
+## Project Overview
+AI Compass is a static website featuring an interactive map of artificial intelligence services tailored for small and medium-sized businesses. The catalog is presented as a radial diagram that visualizes the relationships between each category and service. All logic and data live in a single `index.html` file, so the solution requires no build step, works offline, and can be hosted on any static platform with ease.
 
-## Ціль та мета
-- **Цільова аудиторія**: маркетингові команди, операційні менеджери та підприємці, які шукають надійні AI-інструменти для бізнесу.
-- **Головна мета**: допомогти швидко зорієнтуватися в екосистемі сервісів, підібрати рішення під конкретні завдання та перейти на офіційні сторінки інструментів.
+## Purpose and Goals
+- **Target audience:** marketing teams, operations managers, and entrepreneurs who are searching for reliable AI tools for their business workflows.
+- **Primary goal:** help visitors quickly navigate the AI landscape, choose solutions for specific tasks, and jump to the official product pages.
 
-## Основні можливості
-- Радіальна мапа з центральним вузлом «AI Compass» та кольоровими категоріями сервісів.
-- Перемикання між українською та англійською локалізаціями контенту.
-- Розгортання категорій, груп і підгруп з детальними описами сервісів.
-- Підказки (tooltip) з розширеним описом та прямим посиланням на сервіс при наведенні.
-- Візуальні іконки поруч із назвами, щоб швидко зчитувати тип сервісу.
-- Адаптивна висота полотна для великих каталогів та підтримка клавіатурної навігації.
+## Key Features
+- Radial map with the “AI Compass” central node and color-coded service categories.
+- Toggle between Ukrainian and English content localizations.
+- Expandable categories, groups, and subgroups with detailed service descriptions.
+- Tooltips that surface extended descriptions and direct links to each service on hover.
+- Visual icons next to service names for instant recognition of the service type.
+- Adaptive canvas height for large catalogs plus keyboard navigation support.
 
-## Як користуватися сайтом
-### Швидкий старт
-1. Відкрийте `index.html` у браузері або розгорніть локальний сервер командою `python3 -m http.server 8000` і перейдіть на `http://localhost:8000`.
-2. Перевірте банер у верхній частині сторінки — він описує фокус каталогу.
-3. Ознайомтеся з блоком героя (hero section), що коротко пояснює призначення мапи.
+## How to Use the Site
+### Quick Start
+1. Open `index.html` in your browser, or launch a local server with `python3 -m http.server 8000` and navigate to `http://localhost:8000`.
+2. Review the banner at the top of the page—it explains the catalog’s focus.
+3. Read the hero section, which briefly outlines the purpose of the mind map.
 
-### Навігація по мапі
-1. У центрі знаходиться вузол «AI Compass». Від нього відходять гілки категорій (маркетинг, автоматизація, аналітика тощо).
-2. Натисніть на категорію, щоб розгорнути пов'язані сервіси. Повторний клік згортає категорію.
-3. Якщо категорія містить групи (наприклад, «Відео та кліпи» у маркетингу), натисніть на заголовок групи для перегляду всіх сервісів всередині.
+### Navigating the Map
+1. The “AI Compass” node sits in the center, with branches extending into categories (marketing, automation, analytics, etc.).
+2. Click a category to expand its services. Click again to collapse it.
+3. When a category contains groups (for example, “Video & Clips” inside Marketing), click the group heading to reveal all services inside it.
 
-### Деталі сервісів
-- Наведіть курсор на назву сервісу, щоб побачити опис, ключові сценарії застосування та активне посилання.
-- Клацніть по назві сервісу в підказці, щоб перейти на офіційний сайт (відкриється у новій вкладці).
-- Кожен сервіс позначено іконкою, яка відображає його спеціалізацію (наприклад, 🧩 для DALL·E).
+### Service Details
+- Hover over a service name to see a tooltip containing the description, key use cases, and an active link.
+- Click the service name inside the tooltip to open the official website in a new tab.
+- Each service is paired with an icon that represents its specialization (for example,  for DALL·E).
 
-### Перемикання мов
-- Кнопки **UA** та **EN** у панелі керування дозволяють перемкнути контент на потрібну мову.
-- Після вибору мовні налаштування зберігаються у LocalStorage, тому повторний візит відобразить останню мову.
+### Switching Languages
+- Use the **UA** and **EN** buttons in the control panel to switch the content language.
+- The selected language is stored in LocalStorage, so returning visitors see their last preference automatically.
 
-### Робота з клавіатури
-- Категорії отримують фокус і реагують на клавіші `Enter` або `Space`, тому мапою можна керувати без миші.
-- Для закриття підказки натисніть у довільній точці полотна або наведіть курсор на інший елемент.
+### Keyboard Controls
+- Categories receive focus and react to the `Enter` or `Space` keys, allowing navigation without a mouse.
+- To dismiss a tooltip, click anywhere on the canvas or hover over another element.
 
-## Оновлення каталогу
-- Дані каталогу знаходяться в константі `DATA` всередині `index.html`. Кожна категорія містить перелік сервісів із полями `name`, `href`, `desc`, а також необов'язкові групи `group` -> `items`.
-- Щоб додати новий сервіс, додайте об'єкт у відповідний масив мовної версії (`ua` та `en`), забезпечивши синхронність перекладів.
-- Іконки налаштовуються у словнику `ICONS`. Якщо сервісу немає у словнику, використовується fallback-значок ✨.
+## Updating the Catalog
+- Catalog data lives in the `DATA` constant inside `index.html`. Each category contains a list of services with `name`, `href`, and `desc` fields, plus optional groups structured as `group` → `items`.
+- To add a service, insert an object into the relevant language array (`ua` and `en`) and keep the translations aligned.
+- Icons are configured through the `ICONS` dictionary. If a service is not listed, the fallback ✨ icon is used.
 
-## Розгортання
-- **Локально**: відкрийте `index.html` або підніміть будь-який простий HTTP-сервер.
-- **Cloudflare Pages**: створіть проєкт, залиште порожньою команду збірки та вкажіть корінь (`/`) як вихідну директорію.
-- **GitHub Pages**: оберіть гілку `main` та корінь репозиторію як джерело публікації. Сайт статичний, тому додаткові налаштування не потрібні.
+## Deployment
+- **Local:** open `index.html` directly or spin up any simple HTTP server.
+- **Cloudflare Pages:** create a project, leave the build command empty, and set the output directory to the root (`/`).
+- **GitHub Pages:** publish from the `main` branch and point the source to the repository root. No extra settings are required because the site is static.
 
-## Документація на GitHub Pages
-1. Створено папку `/doc`, яка містить цю документацію й супровідні файли.
-2. У налаштуваннях GitHub Pages можна обрати джерелом папку `/doc`, щоб опублікувати документацію окремо від основного сайту.
-3. Для використання теми GitHub Pages додайте за потреби файл `_config.yml` з темою у цю папку.
+## Documentation on GitHub Pages
+1. The `/doc` folder contains this guide and supporting files.
+2. In GitHub Pages settings you can publish the documentation separately by selecting the `/doc` folder as the source.
+3. To apply a GitHub Pages theme, add a `_config.yml` file with the theme name to this folder.
 
-## Додаткові матеріали
-- [Requirements.md](./Requirements.md) — зібрані функціональні та нефункціональні вимоги.
-- [Backlog.md](./Backlog.md) — пропозиції з покращень і майбутніх завдань.
-- [ADR](./adr) — архітектурні рішення, прийняті під час розробки проєкту.
+## Additional Resources
+- [Requirements.md](./Requirements.md) — functional and non-functional requirements.
+- [Backlog.md](./Backlog.md) — proposed improvements and future tasks.
+- [ADR](./adr) — architecture decisions made during the project.


### PR DESCRIPTION
## Summary
- translate the user guide, requirements, backlog, and ADR documents into English
- update the README project structure comments so every documentation pointer is in English

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d03d4ca6b0832c942441c45373e1fb