### PR TITLE
Use real service logos with fallback

### DIFF
--- a/assets/default-logo.svg
+++ b/assets/default-logo.svg
@@ -1,0 +1,16 @@
+<svg width="64" height="64" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Default service logo">
+  <defs>
+    <linearGradient id="default-logo-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0ea5e9" />
+      <stop offset="100%" stop-color="#1e3a8a" />
+    </linearGradient>
+    <linearGradient id="default-logo-spark" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#f8fafc" stop-opacity="0.85" />
+      <stop offset="100%" stop-color="#e0f2fe" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="url(#default-logo-gradient)" />
+  <circle cx="32" cy="32" r="20" fill="rgba(248, 250, 252, 0.18)" />
+  <path d="M32 17 L35.6 27.4 L46.8 30.4 L36.9 34.2 L34 46.5 L32 37.4 L30 46.5 L27.1 34.2 L17.2 30.4 L28.4 27.4 Z" fill="url(#default-logo-spark)" />
+  <circle cx="32" cy="32" r="4" fill="#0f172a" fill-opacity="0.75" />
+</svg>

--- a/doc/adr/0003-curated-bilingual-catalog.md
+++ b/doc/adr/0003-curated-bilingual-catalog.md
@@ -1,4 +1,4 @@
-# ADR 0003: Curated Bilingual Catalog with Icons
+# ADR 0003: Curated Bilingual Catalog with Branded Visuals
 
 - **Status:** Accepted
 - **Date:** 2025-09-21
@@ -10,12 +10,14 @@ The initial service list was short and failed to reflect key business use cases.
 ## Decision
 - Enrich the `DATA` object with detailed service descriptions in Ukrainian and English while keeping the `ua` and `en` arrays synchronized.
 - Standardize the structure of categories and groups, adding subgroups (for example, “Video & Clips” and “Content & Copywriting”).
-- Add an `ICONS` dictionary that maps popular services to relevant emoji and falls back to ✨ when undefined.
+- Add branded visuals next to each service name. The implementation now resolves real product logos automatically with a
+  graceful fallback badge when a logo cannot be retrieved.
 - Update page text blocks (banner, hero, notes, footer) to support bilingual display.
 
 ## Consequences
 - ✅ Users receive context and usage scenarios without leaving the site.
 - ✅ Bilingual support makes the product suitable for an international audience.
-- ✅ Icons speed up visual scanning and help differentiate services.
+- ✅ Logos speed up visual scanning and help differentiate services.
 - ⚠️ The larger dataset requires thorough translation review with each update.
-- ⚠️ Maintaining icons demands keeping the `ICONS` dictionary in sync when adding new services.
+- ⚠️ Maintaining logo quality requires curating the `LOGO_OVERRIDES` map or per-entry `logo` fields whenever automatic
+  detection is insufficient.

--- a/doc/index.md
+++ b/doc/index.md
@@ -40,11 +40,14 @@ AI Compass is a static website featuring an interactive map of artificial intell
 - To dismiss a tooltip, click anywhere on the canvas or hover over another element.
 
 ## Updating the Catalog
-- Catalog data lives in the `DATA` constant inside `index.html`. Each category contains a list of services with `name`, `href`, and `desc` fields, plus optional groups structured as `group` → `items`.
-- To add a service, insert an object into the relevant language array (`ua` and `en`) and keep the translations aligned.
-- Logos are resolved automatically from each service link (via [logo.clearbit.com](https://logo.clearbit.com/)).
-  Use the `LOGO_OVERRIDES` map in `index.html` to point a service to a different domain or local asset, or set the optional
-  `logo` field directly in the dataset. When a logo cannot be retrieved, the generic `assets/default-logo.svg` badge is used.
+- Catalog data is stored in language-specific JSON files: `data/ua.json` and `data/en.json`. Each category contains a `category`
+  label, a `color`, and a list of services with `name`, `href`, and `desc` fields. Categories may also include groups structured as
+  `group` → `items` for additional nesting.
+- To add or edit a service, update the matching entries in both language files and keep names, descriptions, and URLs aligned.
+- Logos are resolved automatically from each service link through [logo.clearbit.com](https://logo.clearbit.com/). When a
+  product requires a specific image or a local asset, set the optional `logo` field inside the dataset or add an entry in the
+  `LOGO_OVERRIDES` map within `index.html`. If a logo cannot be downloaded, the neutral `assets/default-logo.svg` badge is
+  displayed instead.
 
 ## Deployment
 - **Local:** open `index.html` directly or spin up any simple HTTP server.

--- a/doc/index.md
+++ b/doc/index.md
@@ -12,7 +12,7 @@ AI Compass is a static website featuring an interactive map of artificial intell
 - Toggle between Ukrainian and English content localizations.
 - Expandable categories, groups, and subgroups with detailed service descriptions.
 - Tooltips that surface extended descriptions and direct links to each service on hover.
-- Visual icons next to service names for instant recognition of the service type.
+- Real product logos next to service names for instant recognition.
 - Adaptive canvas height for large catalogs plus keyboard navigation support.
 
 ## How to Use the Site
@@ -29,7 +29,7 @@ AI Compass is a static website featuring an interactive map of artificial intell
 ### Service Details
 - Hover over a service name to see a tooltip containing the description, key use cases, and an active link.
 - Click the service name inside the tooltip to open the official website in a new tab.
-- Each service is paired with an icon that represents its specialization (for example,  for DALL·E).
+- Each service is paired with its official logo when available; a neutral fallback badge is shown otherwise.
 
 ### Switching Languages
 - Use the **UA** and **EN** buttons in the control panel to switch the content language.
@@ -42,7 +42,9 @@ AI Compass is a static website featuring an interactive map of artificial intell
 ## Updating the Catalog
 - Catalog data lives in the `DATA` constant inside `index.html`. Each category contains a list of services with `name`, `href`, and `desc` fields, plus optional groups structured as `group` → `items`.
 - To add a service, insert an object into the relevant language array (`ua` and `en`) and keep the translations aligned.
-- Icons are configured through the `ICONS` dictionary. If a service is not listed, the fallback ✨ icon is used.
+- Logos are resolved automatically from each service link (via [logo.clearbit.com](https://logo.clearbit.com/)).
+  Use the `LOGO_OVERRIDES` map in `index.html` to point a service to a different domain or local asset, or set the optional
+  `logo` field directly in the dataset. When a logo cannot be retrieved, the generic `assets/default-logo.svg` badge is used.
 
 ## Deployment
 - **Local:** open `index.html` directly or spin up any simple HTTP server.

--- a/index.html
+++ b/index.html
@@ -521,6 +521,7 @@
     };
 
     const SUBDOMAIN_STRIP_PREFIXES = new Set(['app', 'apps', 'beta', 'chat', 'studio']);
+    const logoCache = new Map();
 
     function normalizeLogoHost(rawHost) {
       if (!rawHost) return '';
@@ -539,36 +540,63 @@
       return host;
     }
 
-    function resolveLogoSource(service) {
+    function getLogoCacheKey(service) {
       if (!service) return null;
+      if (service.logo && typeof service.logo === 'string') {
+        return `logo:${service.logo}`;
+      }
+      if (service.href && typeof service.href === 'string') {
+        return `href:${service.href.toLowerCase()}`;
+      }
+      if (service.name && typeof service.name === 'string') {
+        return `name:${service.name}`;
+      }
+      return null;
+    }
+
+    function resolveLogoSource(service) {
+      if (!service) return { src: null, cacheKey: null };
+      const cacheKey = getLogoCacheKey(service);
+      if (cacheKey && logoCache.has(cacheKey)) {
+        return { src: logoCache.get(cacheKey) || null, cacheKey };
+      }
+      let src = null;
       if (service.logo) {
-        return service.logo;
-      }
-      const override = LOGO_OVERRIDES[service.name];
-      if (override) {
-        if (typeof override === 'string') {
-          if (/^(?:https?:|data:|assets\//)/.test(override)) {
-            return override;
+        src = service.logo;
+      } else {
+        const override = LOGO_OVERRIDES[service.name];
+        if (override) {
+          if (typeof override === 'string') {
+            if (/^(?:https?:|data:|assets\//)/.test(override)) {
+              src = override;
+            } else {
+              src = `https://logo.clearbit.com/${override}`;
+            }
+          } else if (override.src) {
+            src = override.src;
+          } else if (override.domain) {
+            src = `https://logo.clearbit.com/${override.domain}`;
           }
-          return `https://logo.clearbit.com/${override}`;
         }
-        if (override.src) {
-          return override.src;
-        }
-        if (override.domain) {
-          return `https://logo.clearbit.com/${override.domain}`;
+        if (!src) {
+          const href = service.href;
+          if (href) {
+            try {
+              const url = new URL(href);
+              const normalized = normalizeLogoHost(url.hostname || '');
+              if (normalized) {
+                src = `https://logo.clearbit.com/${normalized}`;
+              }
+            } catch (error) {
+              src = null;
+            }
+          }
         }
       }
-      const href = service.href;
-      if (!href) return null;
-      try {
-        const url = new URL(href);
-        const normalized = normalizeLogoHost(url.hostname || '');
-        if (!normalized) return null;
-        return `https://logo.clearbit.com/${normalized}`;
-      } catch (error) {
-        return null;
+      if (cacheKey) {
+        logoCache.set(cacheKey, src || null);
       }
+      return { src, cacheKey };
     }
 
     function formatLabel(service) {
@@ -579,12 +607,13 @@
         return { text: service, iconHref: FALLBACK_LOGO_SRC, fallbackHref: FALLBACK_LOGO_SRC };
       }
       const text = service.name || '';
-      const iconHref = resolveLogoSource(service) || FALLBACK_LOGO_SRC;
+      const { src, cacheKey } = resolveLogoSource(service);
+      const iconHref = src || FALLBACK_LOGO_SRC;
       return {
         text,
         iconHref,
         fallbackHref: FALLBACK_LOGO_SRC,
-        cacheKey: text,
+        cacheKey,
       };
     }
 
@@ -937,6 +966,7 @@
         const clipUrl = ensureLogoClipPath();
         const fallbackSrc = label.fallbackHref || FALLBACK_LOGO_SRC;
         const iconHref = label.iconHref || fallbackSrc;
+        const cacheKey = label.cacheKey;
         if (iconHref) {
           const iconEl = document.createElementNS('http://www.w3.org/2000/svg', 'image');
           iconEl.setAttribute('width', iconSize);
@@ -959,10 +989,15 @@
           if (fallbackSrc && iconHref !== fallbackSrc) {
             const handleError = () => {
               iconEl.removeEventListener('error', handleError);
+              if (cacheKey) {
+                logoCache.set(cacheKey, null);
+              }
               applyHref(fallbackSrc);
               iconEl.classList.add('node-logo-fallback');
             };
             iconEl.addEventListener('error', handleError);
+          } else if (iconHref === fallbackSrc) {
+            iconEl.classList.add('node-logo-fallback');
           }
           labelGroup.appendChild(iconEl);
           cursorX += iconSize + iconGap;

--- a/index.html
+++ b/index.html
@@ -310,6 +310,13 @@
       font-weight: 600;
       fill: var(--node-text);
     }
+    .node-logo {
+      pointer-events: none;
+      shape-rendering: geometricPrecision;
+    }
+    .node-logo-fallback {
+      filter: saturate(0) brightness(1.25);
+    }
     .large {
       font-size: 16px;
       font-weight: 700;
@@ -492,88 +499,93 @@
       return promise;
     }
 
-    const ICONS = {
-      'ChatGPT': '🧠',
-      'Claude': '🪶',
-      'Google Gemini': '✨',
-      'Microsoft Copilot': '🧭',
-      'Perplexity AI': '🔎',
-      'Mistral Le Chat': '🌬️',
-      'Pi by Inflection': '💬',
-      'You.com': '🔍',
-      'Character.AI': '🎭',
-      'Midjourney': '🎨',
-      'Stable Diffusion': '🌀',
-      'Leonardo AI': '🖌️',
-      'Canva AI': '🖼️',
-      'Adobe Firefly': '🔥',
-      'Ideogram AI': '🔤',
-      'Playground AI': '🛝',
-      'DALL·E': '🧩',
-      'Krea AI': '🌈',
-      'HeyGen': '🗣️',
-      'Synthesia': '🎬',
-      'Runway ML': '🎞️',
-      'Pictory': '🪄',
-      'OpusClip': '📱',
-      'Descript': '🎙️',
-      'Lumen5': '📽️',
-      'Rephrase.ai': '🗣️',
-      'Fliki': '🔊',
-      'Zapier': '⚡',
-      'Make': '🧩',
-      'n8n': '🪢',
-      'UiPath': '🏭',
-      'Power Automate': '🔁',
-      'Bardeen': '🛠️',
-      'Levity': '⚙️',
-      'Axiom.ai': '🧪',
-      'Workato': '🤝',
-      'Coursera': '🎓',
-      'Udemy': '📚',
-      'Docebo': '🏫',
-      'LearnWorlds': '🌐',
-      'Evolv AI': '📈',
-      'Mindsmith': '🧠',
-      'Sana AI': '💡',
-      'Workera': '🧬',
-      'CapCut': '✂️',
-      'VEED.io': '📼',
-      'Copy.ai': '✍️',
-      'Jasper': '🤖',
-      'Notion AI': '🗃️',
-      'Predis.ai': '📝',
-      'Tidio': '💬',
-      'ManyChat': '🤳',
-      'Writesonic': '🚀',
-      'Lately AI': '📊',
-      'Power BI': '📊',
-      'Tableau': '📈',
-      'MonkeyLearn': '🐒',
-      'Crayon': '🖍️',
-      'Crux': '🧱',
-      'Tellius': '🔮',
-      'ThoughtSpot': '🌟',
-      'Obviously AI': '🤔',
-      'Xero': '💼',
-      'QuickBooks': '🧾',
-      'AdCreative.ai': '🎯',
-      'Shopify AI': '🛒',
-      'Wix AI': '🏗️',
-      'Planner 5D': '🏠',
-      'Autodesk AI': '🏢',
-      'Fashwell AI': '👗',
-      'Corti': '📞',
-      'Viz.ai': '🩺',
+    const FALLBACK_LOGO_SRC = 'assets/default-logo.svg';
+
+    const LOGO_OVERRIDES = {
+      'ChatGPT': { domain: 'openai.com' },
+      'Google Gemini': { domain: 'google.com' },
+      'Microsoft Copilot': { domain: 'microsoft.com' },
+      'Mistral Le Chat': { domain: 'mistral.ai' },
+      'Character.AI': { domain: 'character.ai' },
+      'Power Automate': { domain: 'microsoft.com' },
+      'Power BI': { domain: 'powerbi.com' },
+      'QuickBooks': { domain: 'quickbooks.com' },
     };
 
-    const FALLBACK_ICON = '✨';
+    const LOGO_HOST_OVERRIDES = {
+      'gemini.google.com': 'google.com',
+      'copilot.microsoft.com': 'microsoft.com',
+      'powerautomate.microsoft.com': 'microsoft.com',
+      'powerbi.microsoft.com': 'powerbi.com',
+      'quickbooks.intuit.com': 'quickbooks.com',
+    };
 
-    const nodeSizeCache = new Map();
+    const SUBDOMAIN_STRIP_PREFIXES = new Set(['app', 'apps', 'beta', 'chat', 'studio']);
 
-    function formatLabel(name) {
-      const icon = ICONS[name] || FALLBACK_ICON;
-      return `${icon} ${name}`;
+    function normalizeLogoHost(rawHost) {
+      if (!rawHost) return '';
+      const lower = rawHost.toLowerCase();
+      if (LOGO_HOST_OVERRIDES[lower]) {
+        return LOGO_HOST_OVERRIDES[lower];
+      }
+      let host = lower;
+      if (host.startsWith('www.')) {
+        host = host.slice(4);
+      }
+      const segments = host.split('.');
+      if (segments.length > 2 && SUBDOMAIN_STRIP_PREFIXES.has(segments[0])) {
+        host = segments.slice(1).join('.');
+      }
+      return host;
+    }
+
+    function resolveLogoSource(service) {
+      if (!service) return null;
+      if (service.logo) {
+        return service.logo;
+      }
+      const override = LOGO_OVERRIDES[service.name];
+      if (override) {
+        if (typeof override === 'string') {
+          if (/^(?:https?:|data:|assets\//)/.test(override)) {
+            return override;
+          }
+          return `https://logo.clearbit.com/${override}`;
+        }
+        if (override.src) {
+          return override.src;
+        }
+        if (override.domain) {
+          return `https://logo.clearbit.com/${override.domain}`;
+        }
+      }
+      const href = service.href;
+      if (!href) return null;
+      try {
+        const url = new URL(href);
+        const normalized = normalizeLogoHost(url.hostname || '');
+        if (!normalized) return null;
+        return `https://logo.clearbit.com/${normalized}`;
+      } catch (error) {
+        return null;
+      }
+    }
+
+    function formatLabel(service) {
+      if (!service) {
+        return { text: '', iconHref: FALLBACK_LOGO_SRC, fallbackHref: FALLBACK_LOGO_SRC };
+      }
+      if (typeof service === 'string') {
+        return { text: service, iconHref: FALLBACK_LOGO_SRC, fallbackHref: FALLBACK_LOGO_SRC };
+      }
+      const text = service.name || '';
+      const iconHref = resolveLogoSource(service) || FALLBACK_LOGO_SRC;
+      return {
+        text,
+        iconHref,
+        fallbackHref: FALLBACK_LOGO_SRC,
+        cacheKey: text,
+      };
     }
 
     function isGroup(entry) {
@@ -817,7 +829,6 @@
       enBtn.classList.toggle('active', l==='en');
       expanded = null;
       expandedGroups.clear();
-      nodeSizeCache.clear();
       applyCopy();
       if (searchInput) {
         searchInput.value = searchQuery;
@@ -871,39 +882,114 @@
       parent.appendChild(el);
       return el;
     }
+    const LOGO_CLIP_PATH_ID = 'node-logo-rounded';
+
+    function ensureLogoClipPath() {
+      if (!stage) return null;
+      let clip = stage.querySelector(`#${LOGO_CLIP_PATH_ID}`);
+      if (clip) {
+        return `url(#${LOGO_CLIP_PATH_ID})`;
+      }
+      let defs = stage.querySelector('defs');
+      if (!defs) {
+        defs = document.createElementNS('http://www.w3.org/2000/svg', 'defs');
+        if (stage.firstChild) {
+          stage.insertBefore(defs, stage.firstChild);
+        } else {
+          stage.appendChild(defs);
+        }
+      }
+      clip = document.createElementNS('http://www.w3.org/2000/svg', 'clipPath');
+      clip.setAttribute('id', LOGO_CLIP_PATH_ID);
+      clip.setAttribute('clipPathUnits', 'objectBoundingBox');
+      const rect = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+      rect.setAttribute('x', 0);
+      rect.setAttribute('y', 0);
+      rect.setAttribute('width', 1);
+      rect.setAttribute('height', 1);
+      rect.setAttribute('rx', 0.22);
+      rect.setAttribute('ry', 0.22);
+      clip.appendChild(rect);
+      defs.appendChild(clip);
+      return `url(#${LOGO_CLIP_PATH_ID})`;
+    }
+
     function createNode(parent, x, y, label, opts={}) {
       const g = group(parent);
       g.setAttribute('transform', `translate(${x},${y})`);
-      const textEl = document.createElementNS('http://www.w3.org/2000/svg','text');
-      textEl.setAttribute('text-anchor','middle');
-      textEl.setAttribute('dominant-baseline','middle');
-      textEl.setAttribute('class', opts.cls || 'normal');
-      textEl.textContent = label;
-      g.appendChild(textEl);
       const padX = opts.padX ?? 18;
       const padY = opts.padY ?? 12;
       const classKey = opts.cls || 'normal';
-      const cachedByLabel = nodeSizeCache.get(label);
-      let width;
-      let height;
-      if (cachedByLabel && cachedByLabel.has(classKey)) {
-        const cachedSize = cachedByLabel.get(classKey);
-        width = cachedSize.width;
-        height = cachedSize.height;
-      } else {
-        const bbox = textEl.getBBox();
-        width = bbox.width;
-        height = bbox.height;
-        let entry = cachedByLabel;
-        if (!entry) {
-          entry = new Map();
-          nodeSizeCache.set(label, entry);
+      const labelGroup = group(g);
+      labelGroup.setAttribute('class', 'node-label');
+
+      const toText = (value) => {
+        if (value == null) return '';
+        return typeof value === 'string' ? value : String(value);
+      };
+
+      let textEl;
+
+      if (label && typeof label === 'object' && !(label instanceof String)) {
+        const iconSize = label.iconSize ?? (classKey === 'small' ? 20 : classKey === 'large' ? 30 : 24);
+        const iconGap = label.iconGap ?? (classKey === 'small' ? 8 : classKey === 'large' ? 14 : 10);
+        let cursorX = 0;
+        const clipUrl = ensureLogoClipPath();
+        const fallbackSrc = label.fallbackHref || FALLBACK_LOGO_SRC;
+        const iconHref = label.iconHref || fallbackSrc;
+        if (iconHref) {
+          const iconEl = document.createElementNS('http://www.w3.org/2000/svg', 'image');
+          iconEl.setAttribute('width', iconSize);
+          iconEl.setAttribute('height', iconSize);
+          iconEl.setAttribute('x', cursorX);
+          iconEl.setAttribute('y', -iconSize / 2);
+          iconEl.setAttribute('preserveAspectRatio', 'xMidYMid meet');
+          iconEl.setAttribute('class', 'node-logo');
+          iconEl.setAttribute('focusable', 'false');
+          iconEl.setAttribute('aria-hidden', 'true');
+          iconEl.setAttribute('referrerpolicy', label.referrerPolicy || 'no-referrer');
+          if (clipUrl) {
+            iconEl.setAttribute('clip-path', clipUrl);
+          }
+          const applyHref = (value) => {
+            iconEl.setAttribute('href', value);
+            iconEl.setAttributeNS('http://www.w3.org/1999/xlink', 'href', value);
+          };
+          applyHref(iconHref);
+          if (fallbackSrc && iconHref !== fallbackSrc) {
+            const handleError = () => {
+              iconEl.removeEventListener('error', handleError);
+              applyHref(fallbackSrc);
+              iconEl.classList.add('node-logo-fallback');
+            };
+            iconEl.addEventListener('error', handleError);
+          }
+          labelGroup.appendChild(iconEl);
+          cursorX += iconSize + iconGap;
         }
-        entry.set(classKey, { width, height });
+        textEl = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+        textEl.setAttribute('x', cursorX);
+        textEl.setAttribute('y', 0);
+        textEl.setAttribute('text-anchor', 'start');
+        textEl.setAttribute('dominant-baseline', 'middle');
+        textEl.setAttribute('class', classKey);
+        textEl.textContent = toText(label.text);
+        labelGroup.appendChild(textEl);
+      } else {
+        textEl = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+        textEl.setAttribute('text-anchor', 'middle');
+        textEl.setAttribute('dominant-baseline', 'middle');
+        textEl.setAttribute('class', classKey);
+        textEl.textContent = toText(label);
+        labelGroup.appendChild(textEl);
       }
+
+      const bbox = labelGroup.getBBox();
+      const width = bbox.width;
+      const height = bbox.height;
       const rx = width / 2 + padX;
       const ry = height / 2 + padY;
-      const ell = document.createElementNS('http://www.w3.org/2000/svg','ellipse');
+      const ell = document.createElementNS('http://www.w3.org/2000/svg', 'ellipse');
       ell.setAttribute('cx', 0);
       ell.setAttribute('cy', 0);
       ell.setAttribute('rx', rx);
@@ -913,7 +999,12 @@
       if (opts.stroke) ell.setAttribute('stroke', opts.stroke);
       if (opts.sw) ell.setAttribute('stroke-width', opts.sw);
       if (opts.op) ell.setAttribute('opacity', opts.op);
-      g.insertBefore(ell, textEl);
+      g.insertBefore(ell, labelGroup);
+
+      const centerX = bbox.x + width / 2;
+      const centerY = bbox.y + height / 2;
+      labelGroup.setAttribute('transform', `translate(${-centerX}, ${-centerY})`);
+
       return { group: g, text: textEl, ellipse: ell, rx, ry, x, y };
     }
 
@@ -1400,7 +1491,7 @@
               const slotIndex = slotCursor + 1 + svcIdx;
               const itemY = startY + slotIndex * ITEM_SPACING;
               const itemX = pos.side === 'right' ? pos.x + ITEM_GAP : pos.x - ITEM_GAP;
-              const label = formatLabel(svc.name);
+              const label = formatLabel(svc);
               const itemNode = createNode(leafLayer, itemX, itemY, label, {
                 fill: palette.surface,
                 stroke: cat.color,
@@ -1415,7 +1506,7 @@
               itemNode.group.style.cursor = 'pointer';
               itemNode.group.setAttribute('aria-label', svc.name);
               itemNode.group.addEventListener('mouseenter', () =>
-                showTip(itemX, itemY, label, svc.desc, svc.href)
+                showTip(itemX, itemY, svc.name, svc.desc, svc.href)
               );
               itemNode.group.addEventListener('mouseleave', hideTip);
               itemNode.group.addEventListener('click', () => window.open(svc.href, '_blank'));
@@ -1434,7 +1525,7 @@
             const svc = branch.entry;
             const itemY = startY + slotCursor * ITEM_SPACING;
             const itemX = pos.side === 'right' ? pos.x + ITEM_GAP : pos.x - ITEM_GAP;
-            const label = formatLabel(svc.name);
+            const label = formatLabel(svc);
             const itemNode = createNode(leafLayer, itemX, itemY, label, {
               fill: palette.surface,
               stroke: cat.color,
@@ -1449,7 +1540,7 @@
             itemNode.group.style.cursor = 'pointer';
             itemNode.group.setAttribute('aria-label', svc.name);
             itemNode.group.addEventListener('mouseenter', () =>
-              showTip(itemX, itemY, label, svc.desc, svc.href)
+              showTip(itemX, itemY, svc.name, svc.desc, svc.href)
             );
             itemNode.group.addEventListener('mouseleave', hideTip);
             itemNode.group.addEventListener('click', () => window.open(svc.href, '_blank'));

--- a/index.html
+++ b/index.html
@@ -734,8 +734,8 @@
         en: 'No results for this query',
       },
       infoNote: {
-        ua: 'Іконки поруч із назвами допомагають швидко зорієнтуватися. Клікніть категорію, щоб побачити сервіси. Наведіть курсор — опис та посилання.',
-        en: 'Icons highlight each tool. Click a category to expand and hover any service to read the description and open the link.',
+        ua: 'Логотипи поруч із назвами допомагають швидко впізнати сервіси. Клікніть категорію, щоб побачити інструменти, а наведення відкриє опис і посилання.',
+        en: 'Logos next to each name help you recognize tools instantly. Click a category to reveal services, then hover to read the description and open the link.',
       },
       footerRights: {
         ua: 'Усі права захищені · 2024',


### PR DESCRIPTION
## Summary
- render service nodes with real logos resolved from their domains and fall back to a shared badge when none are available
- add rounded logo rendering in the SVG mind map and include a default logo asset
- refresh documentation/ADR to explain the new logo pipeline and overrides

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d058da8494832c8fa3b37443bbfc57